### PR TITLE
Check code validity endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN yarn install --frozen-lockfile --non-interactive
 
 COPY . .
 
+RUN yarn build
+
 EXPOSE 35001
 
 CMD ["node", "dist/src/main"] 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DATABASE: bloom
     ports:
-      - 35001:3000
+      - 35001:35001
     depends_on:
       - db
     volumes:

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { Logger } from './logger/logger';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const PORT = process.env.PORT || 35001;
@@ -20,6 +21,7 @@ async function bootstrap() {
 
   const logger = app.get(Logger);
   app.useLogger(logger);
+  app.useGlobalPipes(new ValidationPipe());
   await app.listen(PORT);
   console.log(`Listening on localhost:${PORT}, CTRL+C to stop`);
 }

--- a/src/partner-access/dto/validate-partner-access.dto.ts
+++ b/src/partner-access/dto/validate-partner-access.dto.ts
@@ -1,12 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDefined, IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
+import { IsDefined, IsNotEmpty, IsString } from 'class-validator';
 
 export class ValidatePartnerAccessCodeDto {
   @IsNotEmpty()
   @IsString()
   @IsDefined()
-  @MaxLength(6)
-  @MinLength(6)
   @ApiProperty({ type: String })
   partnerAccessCode: string;
 }

--- a/src/partner-access/dto/validate-partner-access.dto.ts
+++ b/src/partner-access/dto/validate-partner-access.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDefined, IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class ValidatePartnerAccessCodeDto {
+  @IsNotEmpty()
+  @IsString()
+  @IsDefined()
+  @MaxLength(6)
+  @MinLength(6)
+  @ApiProperty({ type: String })
+  partnerAccessCode: string;
+}

--- a/src/partner-access/partner-access.controller.ts
+++ b/src/partner-access/partner-access.controller.ts
@@ -4,6 +4,7 @@ import { ApiBody, ApiConsumes, ApiProduces, ApiResponse, ApiTags } from '@nestjs
 import { CreatePartnerAccessDto } from './dto/create-partner-access.dto';
 import { PartnerAccessService } from './partner-access.service';
 import { PartnerAccessEntity } from '../entities/partner-access.entity';
+import { ValidatePartnerAccessCodeDto } from './dto/validate-partner-access.dto';
 
 @ApiTags('Partner Access')
 @ApiConsumes('application/json')
@@ -29,5 +30,13 @@ export class PartnerAccessController {
       partnerId,
       partnerAdminId,
     );
+  }
+
+  @Post('validate-code')
+  @ApiBody({ type: ValidatePartnerAccessCodeDto })
+  async validateCode(
+    @Body() { partnerAccessCode }: ValidatePartnerAccessCodeDto,
+  ): Promise<boolean> {
+    return this.partnerAccessService.validatePartnerAccessCode(partnerAccessCode);
   }
 }

--- a/src/partner-access/partner-access.controller.ts
+++ b/src/partner-access/partner-access.controller.ts
@@ -5,7 +5,7 @@ import { CreatePartnerAccessDto } from './dto/create-partner-access.dto';
 import { PartnerAccessService } from './partner-access.service';
 import { PartnerAccessEntity } from '../entities/partner-access.entity';
 import { ValidatePartnerAccessCodeDto } from './dto/validate-partner-access.dto';
-import { PartnerAccessCodeStatusEnum } from 'src/utils/constants';
+import { PartnerAccessCodeStatusEnum } from '../utils/constants';
 
 @ApiTags('Partner Access')
 @ApiConsumes('application/json')

--- a/src/partner-access/partner-access.controller.ts
+++ b/src/partner-access/partner-access.controller.ts
@@ -5,6 +5,7 @@ import { CreatePartnerAccessDto } from './dto/create-partner-access.dto';
 import { PartnerAccessService } from './partner-access.service';
 import { PartnerAccessEntity } from '../entities/partner-access.entity';
 import { ValidatePartnerAccessCodeDto } from './dto/validate-partner-access.dto';
+import { PartnerAccessCodeStatusEnum } from 'src/utils/constants';
 
 @ApiTags('Partner Access')
 @ApiConsumes('application/json')
@@ -36,7 +37,7 @@ export class PartnerAccessController {
   @ApiBody({ type: ValidatePartnerAccessCodeDto })
   async validateCode(
     @Body() { partnerAccessCode }: ValidatePartnerAccessCodeDto,
-  ): Promise<boolean> {
-    return this.partnerAccessService.validatePartnerAccessCode(partnerAccessCode);
+  ): Promise<{ status: PartnerAccessCodeStatusEnum }> {
+    return this.partnerAccessService.validatePartnerAccessCode(partnerAccessCode.toUpperCase());
   }
 }

--- a/src/partner-access/partner-access.service.ts
+++ b/src/partner-access/partner-access.service.ts
@@ -38,4 +38,8 @@ export class PartnerAccessService {
 
     return await this.partnerAccessRepository.save(partnerAccessDetails);
   }
+
+  async validatePartnerAccessCode(partnerAccessCode: string): Promise<boolean> {
+    return !!(await this.partnerAccessRepository.findOne({ accessCode: partnerAccessCode }));
+  }
 }

--- a/src/partner-access/partner-access.service.ts
+++ b/src/partner-access/partner-access.service.ts
@@ -4,7 +4,7 @@ import { CreatePartnerAccessDto } from './dto/create-partner-access.dto';
 import { PartnerAccessRepository } from './partner-access.repository';
 import _ from 'lodash';
 import { PartnerAccessEntity } from '../entities/partner-access.entity';
-import { PartnerAccessCodeStatusEnum } from 'src/utils/constants';
+import { PartnerAccessCodeStatusEnum } from '../utils/constants';
 
 @Injectable()
 export class PartnerAccessService {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,13 @@
 import { UserEntity } from '../entities/user.entity';
 import { GetUserDto } from '../user/dto/get-user.dto';
 
+export enum PartnerAccessCodeStatusEnum {
+  VALID = 'VALID',
+  INVALID_CODE = 'INVALID_CODE',
+  DOES_NOT_EXIST = 'DOES_NOT_EXIST',
+  ALREADY_IN_USE = 'ALREADY_IN_USE',
+}
+
 export const formatUserObject = (userObject: UserEntity): GetUserDto => {
   return {
     user: {


### PR DESCRIPTION
[Ticket](https://www.notion.so/chayn/Check-code-validity-endpoint-6b0a91f3dcd542cfaf71dbc6d27be823)

This PR contains:
- New endpoint to check `partnerAccessCode` validity 
- Code refactor and minor fixes

## New Endpoint 
Endpoint: `api/v1/partner-access/validate-code`

Returns: 

```
  VALID = 'VALID'
  INVALID_CODE = 'INVALID_CODE'
  DOES_NOT_EXIST = 'DOES_NOT_EXIST'
  ALREADY_IN_USE = 'ALREADY_IN_USE'
```

Check swagger to see implementation

## Code refactor
- Fixed issue with Docker not working with port 35001
- Fixed issue with project not building in Docker
- Added validation pipe 