### PR TITLE
Update course session responses

### DIFF
--- a/src/course/course.service.ts
+++ b/src/course/course.service.ts
@@ -16,4 +16,8 @@ export class CourseService {
       .andWhere(`session.status = :status`, { status: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED })
       .getOne();
   }
+
+  async getCourse(id: string): Promise<CourseEntity> {
+    return await this.courseRepository.findOne({ id });
+  }
 }

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -1,8 +1,8 @@
+import { CourseUserEntity } from 'src/entities/course-user.entity';
 import { UserEntity } from '../entities/user.entity';
 import { GetUserDto } from '../user/dtos/get-user.dto';
 
-const getUserCourseSessionDetails = (userObject: UserEntity) => {
-  const courseUserObjects = userObject.courseUser;
+export const formatCourseUserObjects = (courseUserObjects: CourseUserEntity[]) => {
   return courseUserObjects.map((courseUser) => {
     return {
       id: courseUser.course.id,
@@ -11,14 +11,14 @@ const getUserCourseSessionDetails = (userObject: UserEntity) => {
       status: courseUser.course.status,
       storyblokId: courseUser.course.storyblokId,
       completed: courseUser.completed,
-      sessions: courseUser.course.session?.map((session) => {
+      sessions: courseUser.sessionUser?.map((sessionUser) => {
         return {
-          id: session.id,
-          name: session.name,
-          slug: session.slug,
-          storyblokId: session.storyblokId,
-          status: session.status,
-          completed: session.sessionUser[0].completed,
+          id: sessionUser.session.id,
+          name: sessionUser.session.name,
+          slug: sessionUser.session.slug,
+          storyblokId: sessionUser.session.storyblokId,
+          status: sessionUser.session.status,
+          completed: sessionUser.completed,
         };
       }),
     };
@@ -57,7 +57,7 @@ export const formatUserObject = (userObject: UserEntity): GetUserDto => {
           partner: userObject.partnerAdmin.partner,
         }
       : null,
-    courses: userObject.courseUser ? getUserCourseSessionDetails(userObject) : [],
+    courses: userObject.courseUser ? formatCourseUserObjects(userObject.courseUser) : [],
   };
 };
 


### PR DESCRIPTION
It helps the frontend massively to have the responses from `create session` and `complete session`, be the same course and session format, as they are in `/user/me`

I updated the response to make it work for the frontend, tested and all works as expected