### PR TITLE
Add delete account functionality

### DIFF
--- a/src/api/crisp/crisp-api.ts
+++ b/src/api/crisp/crisp-api.ts
@@ -194,3 +194,17 @@ export const updateCrispProfile = async (
     throw error;
   }
 };
+
+export const deleteCrispProfile = async (email: string) => {
+  try {
+    await apiCall({
+      url: `${baseUrl}/people/profile/${email}`,
+      type: 'delete',
+      headers,
+    });
+
+    return 'ok';
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,4 +1,10 @@
-import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  Inject,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { DecodedIdToken } from 'firebase-admin/lib/auth/token-verifier';
 import { FIREBASE } from '../firebase/firebase-factory';
 import { FirebaseServices } from '../firebase/firebase.types';
@@ -33,6 +39,15 @@ export class AuthService {
       return decodedToken;
     } catch (err) {
       throw new UnauthorizedException('Unauthorized: token is expired or invalid');
+    }
+  }
+
+  public async deleteFirebaseUser(firebaseUid: string) {
+    try {
+      await this.firebase.admin.auth().deleteUser(firebaseUid);
+      return 'ok';
+    } catch (error) {
+      throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
     }
   }
 }

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -1,8 +1,8 @@
-import { PartnerAdminEntity } from '../entities/partner-admin.entity';
-import { PartnerAccessEntity } from '../entities/partner-access.entity';
 import { Column, Entity, OneToMany, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
-import { BaseEntity } from './base.entity';
+import { PartnerAccessEntity } from '../entities/partner-access.entity';
+import { PartnerAdminEntity } from '../entities/partner-admin.entity';
 import { LANGUAGE_DEFAULT } from '../utils/constants';
+import { BaseEntity } from './base.entity';
 import { CourseUserEntity } from './course-user.entity';
 
 @Entity({ name: 'user' })
@@ -27,6 +27,9 @@ export class UserEntity extends BaseEntity {
 
   @Column({ type: Boolean, default: false })
   isSuperAdmin: boolean;
+
+  @Column({ type: Boolean, default: true })
+  isActive: boolean;
 
   @OneToMany(() => PartnerAccessEntity, (partnerAccess) => partnerAccess.user)
   partnerAccess: PartnerAccessEntity[];

--- a/src/migrations/1647792481432-bloom_backend.ts
+++ b/src/migrations/1647792481432-bloom_backend.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class bloomBackend1647792481432 implements MigrationInterface {
+    name = 'bloomBackend1647792481432'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" ADD "isActive" boolean NOT NULL DEFAULT true`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "isActive"`);
+    }
+
+}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -25,4 +25,11 @@ export class UserController {
   async getUser(@Req() req: Request): Promise<GetUserDto> {
     return req['user'];
   }
+
+  @ApiBearerAuth()
+  @Post('/delete')
+  @UseGuards(FirebaseAuthGuard)
+  async deleteUser(@Req() req: Request): Promise<string> {
+    return await this.userService.deleteUser(req['user'] as GetUserDto);
+  }
 }

--- a/src/user/user.interface.ts
+++ b/src/user/user.interface.ts
@@ -8,4 +8,5 @@ export interface IUser {
   name: string;
   email: string;
   languageDefault: LANGUAGE_DEFAULT;
+  isActive: boolean;
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,16 +1,16 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { AuthService } from 'src/auth/auth.service';
-import { IFirebaseUser } from 'src/firebase/firebase-user.interface';
-import { generateRandomString, hasFeatureLiveChat } from 'src/utils/utils';
 import {
   addCrispProfile,
   createCrispProfileData,
   deleteCrispProfile,
 } from '../api/crisp/crisp-api';
+import { AuthService } from '../auth/auth.service';
+import { IFirebaseUser } from '../firebase/firebase-user.interface';
 import { PartnerAccessService } from '../partner-access/partner-access.service';
 import { PartnerRepository } from '../partner/partner.repository';
 import { formatUserObject } from '../utils/serialize';
+import { generateRandomString, hasFeatureLiveChat } from '../utils/utils';
 import { CreateUserDto } from './dtos/create-user.dto';
 import { GetUserDto } from './dtos/get-user.dto';
 import { UserRepository } from './user.repository';

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,7 +1,13 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { AuthService } from 'src/auth/auth.service';
 import { IFirebaseUser } from 'src/firebase/firebase-user.interface';
-import { addCrispProfile, createCrispProfileData } from '../api/crisp/crisp-api';
+import { generateRandomString, hasFeatureLiveChat } from 'src/utils/utils';
+import {
+  addCrispProfile,
+  createCrispProfileData,
+  deleteCrispProfile,
+} from '../api/crisp/crisp-api';
 import { PartnerAccessService } from '../partner-access/partner-access.service';
 import { PartnerRepository } from '../partner/partner.repository';
 import { formatUserObject } from '../utils/serialize';
@@ -17,6 +23,7 @@ export class UserService {
     @InjectRepository(PartnerRepository)
     private partnerRepository: PartnerRepository,
     private readonly partnerAccessService: PartnerAccessService,
+    private readonly authService: AuthService,
   ) {}
 
   public async createUser(createUserDto: CreateUserDto): Promise<GetUserDto> {
@@ -84,5 +91,27 @@ export class UserService {
     }
 
     return formatUserObject(queryResult);
+  }
+
+  public async deleteUser({ partnerAccesses, user }: GetUserDto) {
+    //Delete User From Firebase
+    await this.authService.deleteFirebaseUser(user.firebaseUid);
+
+    //Delete Crisp People Profile
+    if (hasFeatureLiveChat(partnerAccesses)) {
+      await deleteCrispProfile(user.email);
+    }
+
+    //Randomise User Data in DB
+    const randomString = generateRandomString(20);
+
+    user.name = randomString;
+    user.email = randomString;
+    user.firebaseUid = randomString;
+    user.isActive = false;
+
+    await this.userRepository.save(user);
+
+    return 'Successful';
   }
 }

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -76,7 +76,9 @@ export const formatUserObject = (userObject: UserEntity): GetUserDto => {
       updatedAt: userObject.updatedAt,
       name: userObject.name,
       email: userObject.email,
+      firebaseUid: userObject.firebaseUid,
       languageDefault: userObject.languageDefault,
+      isActive: userObject.isActive,
     },
     partnerAccesses: userObject.partnerAccess
       ? formatPartnerAccessObjects(userObject.partnerAccess)

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -3,3 +3,7 @@ export const hasFeatureLiveChat = (partnerAccesses) => {
     return pa.featureLiveChat === true;
   });
 };
+
+export const generateRandomString = (length: number) => {
+  return [...Array(length)].map(() => (~~(Math.random() * 36)).toString(36)).join('');
+};


### PR DESCRIPTION
[Ticket](https://www.notion.so/chayn/Add-delete-account-functionality-c6f44b17d4774837b007df07072e0efa)

This PR contains:
- Functionality to delete user account

Delete User Account
1) Deletes users account in Firebase
2) Deletes users account in Crisp (If `featureLiveChat = true`) 
3) Randomises users data (`name, email and firebaseUid`) in the DB
4) New DB column `isActive`. When a users account is delete, this is set to `false`
