### PR TITLE
Allow undo of marking session complete

### DIFF
--- a/src/course-user/course-user.service.ts
+++ b/src/course-user/course-user.service.ts
@@ -38,9 +38,12 @@ export class CourseUserService {
     });
   }
 
-  async completeCourse({ userId, courseId }: CourseUserDto): Promise<CourseUserEntity> {
+  async completeCourse(
+    { userId, courseId }: CourseUserDto,
+    completed: boolean,
+  ): Promise<CourseUserEntity> {
     const courseUser = await this.courseUserRepository.findOne({ where: { userId, courseId } });
-    courseUser.completed = true;
+    courseUser.completed = completed;
     courseUser.completedAt = new Date();
 
     return await this.courseUserRepository.save(courseUser);

--- a/src/course-user/course-user.service.ts
+++ b/src/course-user/course-user.service.ts
@@ -38,13 +38,13 @@ export class CourseUserService {
     });
   }
 
-  async completeCourse(
+  async setCourseUserCompleted(
     { userId, courseId }: CourseUserDto,
     completed: boolean,
   ): Promise<CourseUserEntity> {
     const courseUser = await this.courseUserRepository.findOne({ where: { userId, courseId } });
     courseUser.completed = completed;
-    courseUser.completedAt = new Date();
+    courseUser.completedAt = completed ? new Date() : null;
 
     return await this.courseUserRepository.save(courseUser);
   }

--- a/src/entities/course-user.entity.ts
+++ b/src/entities/course-user.entity.ts
@@ -5,7 +5,7 @@ import {
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
-  Unique
+  Unique,
 } from 'typeorm';
 import { BaseEntity } from './base.entity';
 import { CourseEntity } from './course.entity';

--- a/src/session-user/dtos/session-user.dto.ts
+++ b/src/session-user/dtos/session-user.dto.ts
@@ -16,4 +16,8 @@ export class SessionUserDto {
   @IsBoolean()
   @ApiProperty({ type: Boolean })
   completed?: boolean;
+
+  @IsBoolean()
+  @ApiProperty({ type: Date })
+  completedAt?: Date;
 }

--- a/src/session-user/dtos/update-session-user.dto.ts
+++ b/src/session-user/dtos/update-session-user.dto.ts
@@ -1,9 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDefined, IsNotEmpty } from 'class-validator';
+import { IsBoolean, IsDefined, IsNotEmpty } from 'class-validator';
 
 export class UpdateSessionUserDto {
   @IsNotEmpty()
   @IsDefined()
   @ApiProperty({ type: Number })
   storyblokId: number;
+
+  @IsBoolean()
+  @IsDefined()
+  @IsNotEmpty()
+  @ApiProperty({ type: Boolean })
+  completed: boolean;
 }

--- a/src/session-user/dtos/update-session-user.dto.ts
+++ b/src/session-user/dtos/update-session-user.dto.ts
@@ -1,15 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsDefined, IsNotEmpty } from 'class-validator';
+import { IsDefined, IsNotEmpty } from 'class-validator';
 
 export class UpdateSessionUserDto {
   @IsNotEmpty()
   @IsDefined()
   @ApiProperty({ type: Number })
   storyblokId: number;
-
-  @IsBoolean()
-  @IsDefined()
-  @IsNotEmpty()
-  @ApiProperty({ type: Boolean })
-  completed: boolean;
 }

--- a/src/session-user/session-user.controller.ts
+++ b/src/session-user/session-user.controller.ts
@@ -33,10 +33,26 @@ export class SessionUserController {
   })
   @ApiBearerAuth('access-token')
   @UseGuards(FirebaseAuthGuard)
-  async update(@Req() req: Request, @Body() completeSessionUserDto: UpdateSessionUserDto) {
-    return await this.sessionUserService.completeSessionUser(
+  async complete(@Req() req: Request, @Body() updateSessionUserDto: UpdateSessionUserDto) {
+    return await this.sessionUserService.setSessionUserCompleted(
       req['user'] as GetUserDto,
-      completeSessionUserDto,
+      updateSessionUserDto,
+      true,
+    );
+  }
+
+  @Post('/incomplete')
+  @ApiOperation({
+    description:
+      'Updates a users sessions progress to incomplete, undoing a previous complete action',
+  })
+  @ApiBearerAuth('access-token')
+  @UseGuards(FirebaseAuthGuard)
+  async incomplete(@Req() req: Request, @Body() updateSessionUserDto: UpdateSessionUserDto) {
+    return await this.sessionUserService.setSessionUserCompleted(
+      req['user'] as GetUserDto,
+      updateSessionUserDto,
+      false,
     );
   }
 }


### PR DESCRIPTION
[Ticket](https://www.notion.so/chayn/Allow-undo-of-marking-session-complete-44cb040f57f940d4bc87e7c5810b1a8d)


This PR Contains:
- Allow undo of marking session complete


We planned the logic that if a user can manually mark a session as complete, they should be able to unmark it, in case it was a mistake. 


New `/incomplete` endpoint mirrors the `/complete` endpoint for the frontend