### PR TITLE
Fix missing dependency

### DIFF
--- a/src/partner-admin/partner-admin.module.ts
+++ b/src/partner-admin/partner-admin.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { FirebaseModule } from 'src/firebase/firebase.module';
+import { PartnerAccessRepository } from 'src/partner-access/partner-access.repository';
 import { PartnerRepository } from 'src/partner/partner.repository';
 import { PartnerService } from 'src/partner/partner.service';
 import { UserRepository } from '../user/user.repository';
@@ -10,7 +11,12 @@ import { PartnerAdminService } from './partner-admin.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([PartnerAdminRepository, UserRepository, PartnerRepository]),
+    TypeOrmModule.forFeature([
+      PartnerAdminRepository,
+      PartnerAccessRepository,
+      UserRepository,
+      PartnerRepository,
+    ]),
     FirebaseModule,
   ],
   controllers: [PartnerAdminController],


### PR DESCRIPTION
Fixes import error

bloom-backend | Error: Nest can't resolve dependencies of the PartnerService (PartnerRepository, ?, PartnerAdminRepository, UserRepository). Please make sure that the argument PartnerAccessRepository at index [1] is available in the PartnerAdminModule context.