### PR TITLE
Prevent error information loss

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -38,7 +38,7 @@ export class AuthService {
 
       return decodedToken;
     } catch (err) {
-      throw new UnauthorizedException('Unauthorized: token is expired or invalid');
+      throw new UnauthorizedException(err, 'Unauthorized: token is expired or invalid');
     }
   }
 


### PR DESCRIPTION
When the firebase verify method throws an error, the current implementation does not log the thrown error.
This error is now included in the UnauthorizedException

300522-1850 / Investigate bumble admin login failure