### PR TITLE
Don't throw 500s when auth has gone wrong

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,10 +5,7 @@ module.exports = {
     sourceType: 'module',
   },
   plugins: ['@typescript-eslint/eslint-plugin'],
-  extends: [
-    'plugin:@typescript-eslint/recommended',
-    'plugin:prettier/recommended',
-  ],
+  extends: ['plugin:@typescript-eslint/recommended', 'plugin:prettier/recommended'],
   root: true,
   env: {
     node: true,
@@ -20,5 +17,6 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],
   },
 };

--- a/src/partner-access/partner-access.service.spec.ts
+++ b/src/partner-access/partner-access.service.spec.ts
@@ -1,36 +1,105 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { CourseUserRepository } from '../course-user/course-user.repository';
-import { CourseUserService } from '../course-user/course-user.service';
-import { UserRepository } from '../user/user.repository';
+import { Repository } from 'typeorm';
+import { createQueryBuilderMock } from '../../test/utils/mocks';
+import { PartnerAccessEntity } from '../entities/partner-access.entity';
+import { CreatePartnerAccessDto } from './dtos/create-partner-access.dto';
 import { PartnerAccessRepository } from './partner-access.repository';
 import { PartnerAccessService } from './partner-access.service';
 
-const mockRepository = () => ({});
+const partnerId = 'partnerId1';
+const partnerAdminId = 'partnerAdminId1';
+
+const createPartnerAccessDto: CreatePartnerAccessDto = {
+  featureLiveChat: true,
+  featureTherapy: true,
+  therapySessionsRedeemed: 5,
+  therapySessionsRemaining: 5,
+};
+
+const partnerAccessEntityBase = {
+  id: 'randomId',
+  userId: null,
+  partnerId: '',
+  partnerAdminId: null,
+  user: null,
+  partnerAdmin: null,
+  partner: null,
+  active: false,
+  activatedAt: null,
+  accessCode: null,
+  createdAt: new Date(),
+  therapySession: [],
+  updatedAt: null,
+};
 
 describe('PartnerAccessService', () => {
-  let service: Partial<PartnerAccessService>;
+  let service: PartnerAccessService;
+  let repo: PartnerAccessRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         PartnerAccessService,
-        CourseUserService,
         {
           provide: PartnerAccessRepository,
-          useFactory: mockRepository,
+          useFactory: jest.fn(() => ({
+            createQueryBuilder: createQueryBuilderMock(),
+            create: (dto: CreatePartnerAccessDto): PartnerAccessEntity | Error => {
+              return {
+                ...partnerAccessEntityBase,
+                ...dto,
+              };
+            },
+            save: jest.fn((arg) => arg),
+          })),
         },
-        {
-          provide: CourseUserRepository,
-          useFactory: mockRepository,
-        },
-        { provide: UserRepository, useFactory: mockRepository },
       ],
     }).compile();
 
     service = module.get<PartnerAccessService>(PartnerAccessService);
+    repo = module.get<Repository<PartnerAccessEntity>>(PartnerAccessRepository);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+  describe('createPartnerAccess', () => {
+    it('when supplied with correct data should return access code', async () => {
+      const repoSpyCreate = jest.spyOn(repo, 'create');
+      const repoSpySave = jest.spyOn(repo, 'save');
+
+      const { accessCode: createdAccessCode, ...generatedCode } = await service.createPartnerAccess(
+        createPartnerAccessDto,
+        partnerId,
+        partnerAdminId,
+      );
+      const { accessCode, ...partnerEntityWithoutCode } = partnerAccessEntityBase;
+      expect(generatedCode).toStrictEqual({
+        ...partnerEntityWithoutCode,
+        ...createPartnerAccessDto,
+        partnerAdminId,
+        partnerId,
+      });
+      expect(createdAccessCode).toHaveLength(6);
+      expect(repoSpyCreate).toBeCalledWith(createPartnerAccessDto);
+      expect(repoSpySave).toBeCalled();
+    });
+    it('tries again when it creates a code that already exists', async () => {
+      const repoSpyCreateQueryBuilder = jest.spyOn(repo, 'createQueryBuilder');
+      // Mocks that the accesscode already exists
+      repoSpyCreateQueryBuilder
+        .mockImplementation(
+          createQueryBuilderMock() as never, // TODO resolve this typescript issue
+        )
+        .mockImplementationOnce(
+          createQueryBuilderMock({
+            getOne: jest.fn().mockResolvedValue({ id: 'accessCodeId' }),
+          }) as never,
+        );
+
+      await service.createPartnerAccess(createPartnerAccessDto, partnerId, partnerAdminId);
+      expect(repoSpyCreateQueryBuilder).toBeCalledTimes(2);
+      repoSpyCreateQueryBuilder.mockRestore();
+    });
   });
 });

--- a/src/partner-access/partner-access.service.ts
+++ b/src/partner-access/partner-access.service.ts
@@ -1,5 +1,5 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm/dist/common';
+import { InjectRepository } from '@nestjs/typeorm';
 import _ from 'lodash';
 import moment from 'moment';
 import { updateCrispProfileAccesses } from '../api/crisp/crisp-api';
@@ -21,11 +21,14 @@ export class PartnerAccessService {
     partnerId: string,
     partnerAdminId: string,
   ): Promise<PartnerAccessEntity> {
-    const partnerAccess = this.partnerAccessRepository.create(createPartnerAccessDto);
-    partnerAccess.partnerAdminId = partnerAdminId;
-    partnerAccess.partnerId = partnerId;
-    partnerAccess.accessCode = await this.generateAccessCode(6);
-
+    const partnerAccessBase = this.partnerAccessRepository.create(createPartnerAccessDto);
+    const accessCode = await this.generateAccessCode(6);
+    const partnerAccess = {
+      ...partnerAccessBase,
+      partnerAdminId,
+      partnerId,
+      accessCode,
+    };
     return await this.partnerAccessRepository.save(partnerAccess);
   }
 

--- a/src/partner-admin/partner-admin-auth.guard.spec.ts
+++ b/src/partner-admin/partner-admin-auth.guard.spec.ts
@@ -34,7 +34,7 @@ describe('PartnerAdminAuthGuard', () => {
     guard = new PartnerAdminAuthGuard(mockAuthService, mockUserRepository);
     context = createMock<ExecutionContext>({
       switchToHttp: jest.fn().mockReturnValue({
-        getRequest: jest.fn().mockResolvedValue({ headers: { authorization: 'authed!' } }),
+        getRequest: jest.fn().mockReturnValue({ headers: { authorization: 'authed!' } }),
       }),
     });
   });

--- a/src/partner-admin/partner-admin-auth.guard.spec.ts
+++ b/src/partner-admin/partner-admin-auth.guard.spec.ts
@@ -88,16 +88,4 @@ describe('PartnerAdminAuthGuard', () => {
       expect(error).toBe(badAuthMessage);
     }
   });
-  it('should return false when the authtoken cannot be resolved', async () => {
-    const badAuthMessage = 'bad auth token';
-    jest
-      .spyOn(mockAuthService, 'parseAuth')
-      .mockImplementation(() => Promise.reject(badAuthMessage));
-    try {
-      await guard.canActivate(context);
-      fail('it should not reach here');
-    } catch (error) {
-      expect(error).toBe(badAuthMessage);
-    }
-  });
 });

--- a/src/partner-admin/partner-admin-auth.guard.spec.ts
+++ b/src/partner-admin/partner-admin-auth.guard.spec.ts
@@ -1,0 +1,103 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { ExecutionContext } from '@nestjs/common';
+import { DecodedIdToken } from 'firebase-admin/lib/auth/token-verifier';
+import { AuthService } from 'src/auth/auth.service';
+import { PartnerAdminEntity } from 'src/entities/partner-admin.entity';
+import { UserEntity } from 'src/entities/user.entity';
+import { UserRepository } from 'src/user/user.repository';
+import { createQueryBuilderMock } from '../../test/utils/mocks';
+import { PartnerAdminAuthGuard } from './partner-admin-auth.guard';
+
+const userEntity: UserEntity = {
+  updatedAt: null,
+  createdAt: new Date(),
+  firebaseUid: '123',
+  id: 'userid',
+  email: 'usermail',
+  name: 'name',
+  contactPermission: false,
+  isSuperAdmin: false,
+  partnerAccess: [],
+  partnerAdmin: { id: 'partnerAdminId', partner: {} } as PartnerAdminEntity,
+  isActive: true,
+  courseUser: [],
+};
+describe('PartnerAdminAuthGuard', () => {
+  let guard: PartnerAdminAuthGuard;
+  let mockAuthService: DeepMocked<AuthService>;
+  let mockUserRepository: DeepMocked<UserRepository>;
+  let context: ExecutionContext;
+
+  beforeEach(() => {
+    mockAuthService = createMock<AuthService>();
+    mockUserRepository = createMock<UserRepository>();
+    guard = new PartnerAdminAuthGuard(mockAuthService, mockUserRepository);
+    context = createMock<ExecutionContext>({
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockResolvedValue({ headers: { authorization: 'authed!' } }),
+      }),
+    });
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  it('should return true when the user is a partner admin', async () => {
+    jest.spyOn(mockAuthService, 'parseAuth').mockImplementation(() =>
+      Promise.resolve({
+        uid: 'uuid',
+      } as DecodedIdToken),
+    );
+    jest.spyOn(mockUserRepository, 'createQueryBuilder').mockImplementationOnce(
+      createQueryBuilderMock({
+        getOne: jest.fn().mockResolvedValue(userEntity),
+      }) as never, // TODO resolve this typescript issue
+    );
+
+    const canActivate = await guard.canActivate(context);
+
+    expect(canActivate).toBe(true);
+  });
+  it('should return false when the user is not a partner admin', async () => {
+    jest.spyOn(mockAuthService, 'parseAuth').mockImplementation(() =>
+      Promise.resolve({
+        uid: 'uuid',
+      } as DecodedIdToken),
+    );
+    jest.spyOn(mockUserRepository, 'createQueryBuilder').mockImplementationOnce(
+      createQueryBuilderMock({
+        getOne: jest.fn().mockResolvedValue({ ...userEntity, partnerAdmin: null }),
+      }) as never, // TODO resolve this typescript issue
+    );
+
+    const canActivate = await guard.canActivate(context);
+
+    expect(canActivate).toBe(false);
+  });
+
+  it('should return false when the authtoken cannot be resolved', async () => {
+    const badAuthMessage = 'bad auth token';
+    jest
+      .spyOn(mockAuthService, 'parseAuth')
+      .mockImplementation(() => Promise.reject(badAuthMessage));
+    try {
+      await guard.canActivate(context);
+      fail('it should not reach here');
+    } catch (error) {
+      expect(error).toBe(badAuthMessage);
+    }
+  });
+  it('should return false when the authtoken cannot be resolved', async () => {
+    const badAuthMessage = 'bad auth token';
+    jest
+      .spyOn(mockAuthService, 'parseAuth')
+      .mockImplementation(() => Promise.reject(badAuthMessage));
+    try {
+      await guard.canActivate(context);
+      fail('it should not reach here');
+    } catch (error) {
+      expect(error).toBe(badAuthMessage);
+    }
+  });
+});

--- a/src/partner-admin/partner-admin-auth.guard.ts
+++ b/src/partner-admin/partner-admin-auth.guard.ts
@@ -8,7 +8,7 @@ export class PartnerAdminAuthGuard implements CanActivate {
   constructor(private authService: AuthService, private usersRepository: UserRepository) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const request = await context.switchToHttp().getRequest<Request>();
+    const request = context.switchToHttp().getRequest<Request>();
     const { authorization } = request.headers;
     if (!authorization) {
       return false;

--- a/test/utils/mocks.ts
+++ b/test/utils/mocks.ts
@@ -1,0 +1,14 @@
+export const createQueryBuilderMock = (modifications?: Record<string, jest.Mock<any, any>>) =>
+  jest.fn(() => ({
+    where: jest.fn().mockReturnThis(),
+    setParameter: jest.fn().mockReturnThis(),
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    getOne: jest.fn().mockResolvedValue(undefined),
+    delete: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockReturnThis(),
+    offset: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    getManyAndCount: jest.fn().mockReturnValueOnce({}),
+    ...modifications,
+  }));


### PR DESCRIPTION
- I noticed that when you were unauthorised and tried to create an access code, the api returned with a 500.
- I decided to fix this issue with the auth first and return with a 403 - forbidden. 
- I removed errors thrown because this makes it look like it is an error on our behalf when it really isn't. 500s should be for cases that are really bad, not lack of authorisation. 
- I added a test for the auth guard
- I added a test for generate access code
- Note that I have decided to ignore the type issue for now because I spent too much time on it already. 