### PR TITLE
[HIGH LEVEL] Remove unused params from createCrispProfile and use updateCrispProfile

### DIFF
--- a/src/api/crisp/crisp-api.interfaces.ts
+++ b/src/api/crisp/crisp-api.interfaces.ts
@@ -11,9 +11,6 @@ export interface NewPeopleProfile {
   person: {
     nickname: string;
   };
-  data: {
-    [key: string]: string | number | boolean;
-  };
 }
 
 export interface NewPeopleProfileResponse extends CrispResponse {

--- a/src/api/crisp/crisp-api.ts
+++ b/src/api/crisp/crisp-api.ts
@@ -34,14 +34,21 @@ export const updateCrispProfileAccesses = async (
 
   if (!!hasCrispProfile) {
     // Crisp profile exists, just update/replace PartnerAccess data
-    updateCrispProfileData(createCrispProfileData(user, partnerAccesses, courses), user.email);
+
+    await updateCrispProfileData(
+      createCrispProfileData(user, partnerAccesses, courses),
+      user.email,
+    );
   } else {
     // Create new crisp profile
-    addCrispProfile({
+    await addCrispProfile({
       email: user.email,
       person: { nickname: user.name },
-      data: createCrispProfileData(user, partnerAccesses, courses),
     });
+    await updateCrispProfileData(
+      createCrispProfileData(user, partnerAccesses, courses),
+      user.email,
+    );
   }
 
   return 'ok';

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -61,16 +61,11 @@ export class UserService {
           ? { ...partnerAccessResponse, partner: partnerResponse }
           : undefined;
 
-      // Creates the profile - TODO - possibly remove the data section of this request
       await addCrispProfile({
         email: createUserResponse.email,
         person: { nickname: createUserResponse.name },
-        data: createCrispProfileData(
-          createUserResponse,
-          partnerAccessWithPartner ? [partnerAccessWithPartner] : [],
-        ),
       });
-      // Updates the profile data
+
       await updateCrispProfileData(
         createCrispProfileData(
           createUserResponse,


### PR DESCRIPTION
- See https://docs.crisp.chat/references/rest-api/v1/#add-new-people-profile - no data parameter
- we need to use a separate request https://docs.crisp.chat/references/rest-api/v1/#save-people-data to update data. I tested on staging and it works.