### PR TITLE
Simplybook webhook fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,8 @@
   },
   "[jsonc]": {
     "editor.defaultFormatter": "vscode.json-language-features"
-  }
+  },
+  "cSpell.words": [
+    "simplybook"
+  ]
 }

--- a/src/api/slack/slack-api.ts
+++ b/src/api/slack/slack-api.ts
@@ -1,0 +1,24 @@
+import { Injectable, Logger } from '@nestjs/common';
+import apiCall from '../apiCalls';
+
+@Injectable()
+export class SlackMessageClient {
+  private readonly logger = new Logger('SlackClient');
+
+  public async sendMessageToTherapySlackChannel(text: string) {
+    try {
+      const response = await apiCall({
+        url: process.env.SLACK_WEBHOOK_URL,
+        type: 'post',
+        data: {
+          text: text,
+        },
+      });
+      this.logger.log('Message sent to slack Therapy Channel');
+      return response;
+    } catch (err) {
+      this.logger.error('Unable to sendMessageToTherapySlackChannel');
+      return err;
+    }
+  }
+}

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -6,7 +6,7 @@ import { PartnerAccessEntity } from 'src/entities/partner-access.entity';
 import { PartnerEntity } from 'src/entities/partner.entity';
 import { PartnerAccessCodeStatusEnum } from 'src/utils/constants';
 import { mockIFirebaseUser, mockUserEntity } from 'test/utils/mockData';
-import { mockUserRepositoryMethods } from 'test/utils/mockedServices';
+import { mockUserRepositoryMethodsFactory } from 'test/utils/mockedServices';
 import { Repository } from 'typeorm';
 import { createQueryBuilderMock } from '../../test/utils/mockUtils';
 import { AuthService } from '../auth/auth.service';
@@ -51,7 +51,7 @@ describe('UserService', () => {
         UserService,
         {
           provide: UserRepository,
-          useFactory: jest.fn(() => mockUserRepositoryMethods),
+          useFactory: jest.fn(() => mockUserRepositoryMethodsFactory),
         },
         {
           provide: PartnerService,

--- a/src/webhooks/webhooks.controller.ts
+++ b/src/webhooks/webhooks.controller.ts
@@ -16,7 +16,12 @@ export class WebhooksController {
   @Post('simplybook')
   @ApiBody({ type: SimplybookBodyDto })
   async updatePartnerAccessTherapy(@Body() simplybookBodyDto: SimplybookBodyDto): Promise<string> {
-    return this.webhooksService.updatePartnerAccessTherapy(simplybookBodyDto);
+    try {
+      await this.webhooksService.updatePartnerAccessTherapy(simplybookBodyDto);
+      return 'Successful';
+    } catch (err) {
+      throw err;
+    }
   }
 
   @UseGuards(ZapierAuthGuard)

--- a/test/utils/mockData.ts
+++ b/test/utils/mockData.ts
@@ -1,8 +1,11 @@
 import { CourseEntity } from 'src/entities/course.entity';
+import { PartnerAccessEntity } from 'src/entities/partner-access.entity';
 import { SessionEntity } from 'src/entities/session.entity';
+import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
 import { UserEntity } from 'src/entities/user.entity';
 import { IFirebaseUser } from 'src/firebase/firebase-user.interface';
-import { STORYBLOK_STORY_STATUS_ENUM } from 'src/utils/constants';
+import { SimplybookBodyDto } from 'src/partner-access/dtos/zapier-body.dto';
+import { SIMPLYBOOK_ACTION_ENUM, STORYBLOK_STORY_STATUS_ENUM } from 'src/utils/constants';
 import { StoryblokResult } from 'storyblok-js-client';
 
 export const mockSessionStoryblokResult = {
@@ -123,3 +126,43 @@ export const mockUserEntity: UserEntity = {
   email: 'user@email.com',
   name: 'name',
 };
+
+export const mockTherapySessionEntity = {
+  action: SIMPLYBOOK_ACTION_ENUM.NEW_BOOKING,
+  createdAt: new Date(),
+  partnerAccessId: 'pa1',
+  partnerAccess: { id: 'pa1' } as PartnerAccessEntity,
+  updatedAt: new Date(),
+  serviceName: 'bloomtherapy',
+  serviceProviderEmail: 'therapist@test.com',
+  serviceProviderName: 'Therapist name',
+  bookingCode: '123',
+  clientTimezone: 'Europe/London',
+  clientEmail: 'client@test.com',
+  name: 'client name',
+  startDateTime: new Date('2022-09-12T07:30:00+0100'),
+  endDateTime: new Date('2022-09-12T08:30:00+0100'),
+  cancelledAt: null,
+  rescheduledFrom: null,
+  completedAt: null,
+  id: 'ts1',
+} as TherapySessionEntity;
+
+export const simplybookBodyBase: SimplybookBodyDto = {
+  action: SIMPLYBOOK_ACTION_ENUM.UPDATED_BOOKING,
+  start_date_time: '2022-09-12T07:30:00+0000',
+  end_date_time: '2022-09-12T08:30:00+0000',
+  client_email: 'testuser@test.com',
+  client_timezone: 'Europe/London',
+  booking_code: 'abc',
+  service_name: 'bloom therapy',
+  service_provider_email: 'therapist@test.com',
+  service_provider_name: 'therapist@test.com',
+};
+
+export const mockPartnerAccessEntity = {
+  id: 'pa1',
+  therapySessionsRemaining: 5,
+  therapySessionsRedeemed: 1,
+  featureTherapy: true,
+} as PartnerAccessEntity;

--- a/test/utils/mockedServices.ts
+++ b/test/utils/mockedServices.ts
@@ -1,13 +1,25 @@
 import { PartialFuncReturn } from '@golevelup/ts-jest';
+import { SlackMessageClient } from 'src/api/slack/slack-api';
 import { CoursePartnerService } from 'src/course-partner/course-partner.service';
 import { CourseRepository } from 'src/course/course.repository';
 import { CourseEntity } from 'src/entities/course.entity';
+import { PartnerAccessEntity } from 'src/entities/partner-access.entity';
 import { SessionEntity } from 'src/entities/session.entity';
+import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
 import { UserEntity } from 'src/entities/user.entity';
+import { PartnerAccessRepository } from 'src/partner-access/partner-access.repository';
 import { SessionRepository } from 'src/session/session.repository';
 import { CreateUserDto } from 'src/user/dtos/create-user.dto';
 import { UpdateUserDto } from 'src/user/dtos/update-user.dto';
-import { mockCourse, mockSession, mockUserEntity } from './mockData';
+import { UserRepository } from 'src/user/user.repository';
+import { TherapySessionRepository } from 'src/webhooks/therapy-session.repository';
+import {
+  mockCourse,
+  mockPartnerAccessEntity,
+  mockSession,
+  mockTherapySessionEntity,
+  mockUserEntity,
+} from './mockData';
 import { createQueryBuilderMock } from './mockUtils';
 
 export const mockSessionRepositoryMethods: PartialFuncReturn<SessionRepository> = {
@@ -39,8 +51,26 @@ export const mockCoursePartnerRepositoryMethods: PartialFuncReturn<CoursePartner
     return [];
   },
 };
+export const mockTherapySessionRepositoryMethods: PartialFuncReturn<TherapySessionRepository> = {
+  findOne: async (arg) => {
+    return { ...mockTherapySessionEntity, ...(arg ? arg : {}) } as TherapySessionEntity;
+  },
+  save: async (arg) => arg as TherapySessionEntity,
+};
 
-export const mockUserRepositoryMethods = {
+export const mockUserRepositoryMethods: PartialFuncReturn<UserRepository> = {
+  create: (dto: CreateUserDto) => {
+    return {
+      ...mockUserEntity,
+      ...dto,
+    } as UserEntity;
+  },
+  findOne: async ({ email: client_email }) => {
+    return { ...mockUserEntity, ...(client_email ? { email: client_email } : {}) } as UserEntity;
+  },
+};
+
+export const mockUserRepositoryMethodsFactory = {
   createQueryBuilder: createQueryBuilderMock(),
   create: (dto: CreateUserDto): UserEntity | Error => {
     return {
@@ -48,14 +78,36 @@ export const mockUserRepositoryMethods = {
       ...dto,
     };
   },
-  update: (dto: UpdateUserDto): UserEntity | Error => {
+  update: (dto: UpdateUserDto) => {
     return {
       ...mockUserEntity,
       ...dto,
     };
   },
-  findOne: () => {
-    return mockUserEntity;
+  findOne: ({ email: client_email }) => {
+    return { ...mockUserEntity, ...(client_email ? { email: client_email } : {}) };
   },
   save: (arg) => arg,
+};
+
+export const mockPartnerAccessRepositoryMethods: PartialFuncReturn<PartnerAccessRepository> = {
+  create: (dto) => {
+    return {
+      ...mockPartnerAccessEntity,
+      ...dto,
+    } as PartnerAccessEntity;
+  },
+  findOne: async (arg) => {
+    return { ...mockPartnerAccessEntity, ...(arg ? { ...arg } : {}) } as PartnerAccessEntity;
+  },
+  find: async (arg) => {
+    return [{ ...mockPartnerAccessEntity, ...(arg ? { ...arg } : {}) }] as PartnerAccessEntity[];
+  },
+  save: async (arg) => arg as PartnerAccessEntity,
+};
+
+export const mockSlackMessageClientMethods: PartialFuncReturn<SlackMessageClient> = {
+  sendMessageToTherapySlackChannel: async () => {
+    return;
+  },
 };


### PR DESCRIPTION
- Added tests to simply book webhook
- Cancel and update  booking shouldn't require any therapy sessions remaining. 
- Update shouldn't change partner access
- Separated slack api call so I could test

Note - review to the degree you think necessary. Perhaps we are going to retire the endpoint at some point so maybe just a glance through is fine. 