### PR TITLE
[HIGH LEVEL] Update segments to crisp when users sign up or apply code

### DIFF
--- a/src/api/crisp/crisp-api.interfaces.ts
+++ b/src/api/crisp/crisp-api.interfaces.ts
@@ -5,12 +5,27 @@ export interface CrispResponse {
     data: unknown;
   };
 }
-
+export interface CrispProfileResponse {
+  error: boolean;
+  reason: string;
+  data: {
+    segments: string[];
+  };
+}
 export interface NewPeopleProfile {
   email: string;
   person: {
     nickname: string;
   };
+  segments: string[];
+}
+
+export interface UpdatePeopleProfile {
+  email?: string;
+  person?: {
+    nickname: string;
+  };
+  segments?: string[];
 }
 
 export interface NewPeopleProfileResponse extends CrispResponse {

--- a/src/api/crisp/crisp-api.spec.ts
+++ b/src/api/crisp/crisp-api.spec.ts
@@ -1,0 +1,83 @@
+import { AxiosResponse } from 'axios';
+import apiCall from 'src/api/apiCalls';
+import { crispWebsiteId } from 'src/utils/constants';
+import { mockPartnerAccessEntity, mockPartnerEntity, mockUserEntity } from 'test/utils/mockData';
+import { updateCrispProfileAccesses } from './crisp-api';
+import { CrispProfileResponse, CrispResponse } from './crisp-api.interfaces';
+
+jest.mock('src/api/apiCalls');
+
+describe('CrispApi', () => {
+  describe('updateCrispProfileAccesses', () => {
+    it('should updateCrispProfile', async () => {
+      const mockedApiCall = apiCall as jest.MockedFunction<typeof apiCall>;
+      mockedApiCall
+        .mockImplementationOnce(
+          async () =>
+            ({
+              data: { error: false, reason: 'resolved', data: {} },
+            } as AxiosResponse<CrispResponse>),
+        )
+        .mockImplementationOnce(
+          async () =>
+            ({
+              data: { error: false, reason: 'resolved', data: {} },
+            } as AxiosResponse<CrispResponse>),
+        )
+        .mockImplementationOnce(
+          async () =>
+            ({
+              data: { error: false, reason: 'resolved', data: { segments: ['public'] } },
+            } as AxiosResponse<CrispProfileResponse>),
+        );
+
+      // Clear the mock so the next test starts with fresh data
+
+      await updateCrispProfileAccesses(
+        mockUserEntity,
+        [{ ...mockPartnerAccessEntity, partner: mockPartnerEntity }],
+        [],
+      );
+      const baseUrl = `https://api.crisp.chat/v1/website/${crispWebsiteId}`;
+      // request to get profile data
+      expect(apiCall).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          url: `${baseUrl}/people/data/${mockUserEntity.email}`,
+          type: 'get',
+        }),
+      );
+
+      expect(apiCall).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          // updating people data
+          url: `${baseUrl}/people/data/${mockUserEntity.email}`,
+          type: 'patch',
+        }),
+      );
+      expect(apiCall).toHaveBeenNthCalledWith(
+        3,
+        // request to get
+        expect.objectContaining({
+          // request to update profile
+          url: `${baseUrl}/people/profile/${mockUserEntity.email}`,
+          type: 'get',
+        }),
+      );
+      expect(apiCall).toHaveBeenNthCalledWith(
+        4,
+        // request to get
+        expect.objectContaining({
+          // request to update profile
+          url: `${baseUrl}/people/profile/${mockUserEntity.email}`,
+          type: 'patch',
+          data: expect.objectContaining({
+            segments: ['bumble', 'public'],
+          }),
+        }),
+      );
+      mockedApiCall.mockClear();
+    });
+  });
+});

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -1,7 +1,7 @@
 import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import apiCall from 'src/api/apiCalls';
+import { addCrispProfile } from 'src/api/crisp/crisp-api';
 import { PartnerAccessEntity } from 'src/entities/partner-access.entity';
 import { PartnerEntity } from 'src/entities/partner.entity';
 import { PartnerAccessCodeStatusEnum } from 'src/utils/constants';
@@ -30,7 +30,7 @@ const updateUserDto: UpdateUserDto = {
   contactPermission: true,
 };
 
-jest.mock('src/api/apiCalls');
+jest.mock('src/api/crisp/crisp-api');
 
 describe('UserService', () => {
   let service: UserService;
@@ -90,7 +90,11 @@ describe('UserService', () => {
       expect(user.partnerAccesses).toBe(undefined);
       expect(repoSpyCreate).toBeCalledWith(createUserDto);
       expect(repoSpySave).toBeCalled();
-      expect(apiCall).toBeCalled();
+      expect(addCrispProfile).toBeCalledWith({
+        email: user.user.email,
+        person: { nickname: 'name' },
+        segments: ['public'],
+      });
     });
     it('when supplied with user dto and partner access, it should return a new partner user', async () => {
       const repoSpyCreate = jest.spyOn(repo, 'create');
@@ -116,7 +120,7 @@ describe('UserService', () => {
         } as PartnerAccessEntity);
       const partnerRepoSpy = jest
         .spyOn(mockPartnerRepository, 'findOne')
-        .mockResolvedValue({ id: '123' } as PartnerEntity);
+        .mockResolvedValue({ id: '123', name: 'Bumble' } as PartnerEntity);
 
       const user = await service.createUser({ ...createUserDto, partnerAccessCode: '123456' });
       expect(user.user.email).toBe('user@email.com');
@@ -143,7 +147,11 @@ describe('UserService', () => {
       expect(partnerRepoSpy).toBeCalled();
       expect(repoSpySave).toBeCalled();
 
-      expect(apiCall).toBeCalled();
+      expect(addCrispProfile).toBeCalledWith({
+        email: user.user.email,
+        person: { nickname: 'name' },
+        segments: ['bumble'],
+      });
     });
 
     it('when supplied with user dto and partner access that has already been used, it should return an error', async () => {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -60,10 +60,14 @@ export class UserService {
         partnerResponse && partnerAccessResponse
           ? { ...partnerAccessResponse, partner: partnerResponse }
           : undefined;
+      const partnerSegment = partnerAccessWithPartner
+        ? partnerAccessWithPartner.partner.name
+        : 'public';
 
       await addCrispProfile({
         email: createUserResponse.email,
         person: { nickname: createUserResponse.name },
+        segments: [partnerSegment.toLowerCase()],
       });
 
       await updateCrispProfileData(

--- a/test/utils/mockData.ts
+++ b/test/utils/mockData.ts
@@ -1,6 +1,7 @@
 import { CourseEntity } from 'src/entities/course.entity';
 import { EmailCampaignEntity } from 'src/entities/email-campaign.entity';
 import { PartnerAccessEntity } from 'src/entities/partner-access.entity';
+import { PartnerEntity } from 'src/entities/partner.entity';
 import { SessionEntity } from 'src/entities/session.entity';
 import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
 import { UserEntity } from 'src/entities/user.entity';
@@ -171,6 +172,7 @@ export const mockPartnerAccessEntity = {
   therapySessionsRedeemed: 1,
   featureTherapy: true,
 } as PartnerAccessEntity;
+export const mockPartnerEntity = { name: 'Bumble' } as PartnerEntity;
 
 export const mockEmailCampaignEntity: EmailCampaignEntity = {
   email: 'test@test.com',


### PR DESCRIPTION
- created tests for crisp api
- bumble and public are lower case as segments are all lower case
- opted to go for the concat option. As in a user might start out as public and bumble and badoo rather than either or. We can change this if we want but its an easy starting point. 
