### PR TITLE
[FYI] Allow multiple access per partner

### DIFF
--- a/src/api/crisp/crisp-api.ts
+++ b/src/api/crisp/crisp-api.ts
@@ -46,7 +46,9 @@ export const updateCrispProfileAccesses = async (
     );
     const profileData = await getCrispProfile(user.email);
     const profileSegments = profileData?.data?.data?.segments;
-    const segments = partnerSegment.concat(profileSegments ? profileSegments : []);
+    const segments = partnerSegment
+      .concat(profileSegments ? profileSegments : [])
+      .filter((segment, index, array) => array.indexOf(segment) === index);
     await updateCrispProfile({ segments: segments }, user.email);
   } else {
     // Create new crisp profile

--- a/src/api/crisp/crisp-api.ts
+++ b/src/api/crisp/crisp-api.ts
@@ -48,6 +48,7 @@ export const updateCrispProfileAccesses = async (
     const profileSegments = profileData?.data?.data?.segments;
     const segments = partnerSegment
       .concat(profileSegments ? profileSegments : [])
+      // Remove duplicate segments as crisp will fail if it finds duplicates
       .filter((segment, index, array) => array.indexOf(segment) === index);
     await updateCrispProfile({ segments: segments }, user.email);
   } else {


### PR DESCRIPTION
There seemed very little to change for this.
I removed the need to make partner access active=false if it is a secondary access code for a partner. This questions the necessity of the "active" flag.  Leaving for now but worth coming back to for the future. 