### PR TITLE
[HIGH LEVEL] Create partner access user by supplying partnerId

### DIFF
--- a/src/partner-access/partner-access.service.spec.ts
+++ b/src/partner-access/partner-access.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import * as crispApi from 'src/api/crisp/crisp-api';
 import { GetUserDto } from 'src/user/dtos/get-user.dto';
-import { mockUserEntity } from 'test/utils/mockData';
+import { mockPartnerEntity, mockUserEntity } from 'test/utils/mockData';
 import { Repository } from 'typeorm';
 import { createQueryBuilderMock } from '../../test/utils/mockUtils';
 import { PartnerAccessEntity } from '../entities/partner-access.entity';
@@ -158,6 +158,21 @@ describe('PartnerAccessService', () => {
         userId: mockGetUserDto.user.id,
         activatedAt: partnerAccess.activatedAt, // need to just fudge this as it is test specific
       });
+    });
+  });
+  describe('assignPartnerAccessOnSignUp', () => {
+    it('when partnerId is supplied, it should create a partner access and assign to user', async () => {
+      const partnerAccess = await service.assignPartnerAccessOnSignup({
+        partnerId: mockPartnerEntity.id,
+        userId: mockGetUserDto.user.id,
+      });
+
+      expect(partnerAccess.partnerAdminId).toBeNull();
+      expect(partnerAccess.partnerAdmin).toBeNull();
+
+      expect(partnerAccess.userId).toBe(mockGetUserDto.user.id);
+      expect(partnerAccess.featureLiveChat).toBeTruthy();
+      expect(partnerAccess.featureTherapy).toBeFalsy();
     });
   });
 });

--- a/src/partner-access/partner-access.service.spec.ts
+++ b/src/partner-access/partner-access.service.spec.ts
@@ -171,22 +171,6 @@ describe('PartnerAccessService', () => {
     });
   });
   describe('assignPartnerAccessOnSignUp', () => {
-    it('when partnerId is supplied, it should create a partner access and assign to user', async () => {
-      const validCodeSpy = jest.spyOn(service, 'getValidPartnerAccessCode');
-
-      const partnerAccess = await service.assignPartnerAccessOnSignup({
-        partnerId: mockPartnerEntity.id,
-        userId: mockGetUserDto.user.id,
-      });
-
-      expect(partnerAccess.partnerAdminId).toBeNull();
-      expect(partnerAccess.partnerAdmin).toBeNull();
-
-      expect(partnerAccess.userId).toBe(mockGetUserDto.user.id);
-      expect(partnerAccess.featureLiveChat).toBeTruthy();
-      expect(partnerAccess.featureTherapy).toBeFalsy();
-      expect(validCodeSpy).toBeCalledTimes(0);
-    });
     it('when partnerAccess is supplied, it should create a partner access and assign to user', async () => {
       const validCodeSpy = jest.spyOn(service, 'getValidPartnerAccessCode');
       jest.spyOn(repo, 'createQueryBuilder').mockImplementationOnce(
@@ -206,6 +190,24 @@ describe('PartnerAccessService', () => {
       expect(partnerAccess.featureLiveChat).toBeTruthy();
       expect(partnerAccess.featureTherapy).toBeTruthy();
       expect(validCodeSpy).toBeCalled();
+    });
+  });
+  describe('assignPartnerAccessOnSignUpWithoutCode', () => {
+    it('when partnerId is supplied, it should create a partner access and assign to user', async () => {
+      const validCodeSpy = jest.spyOn(service, 'getValidPartnerAccessCode');
+
+      const partnerAccess = await service.assignPartnerAccessOnSignupWithoutCode({
+        partnerId: mockPartnerEntity.id,
+        userId: mockGetUserDto.user.id,
+      });
+
+      expect(partnerAccess.partnerAdminId).toBeNull();
+      expect(partnerAccess.partnerAdmin).toBeNull();
+
+      expect(partnerAccess.userId).toBe(mockGetUserDto.user.id);
+      expect(partnerAccess.featureLiveChat).toBeTruthy();
+      expect(partnerAccess.featureTherapy).toBeFalsy();
+      expect(validCodeSpy).toBeCalledTimes(0);
     });
   });
 });

--- a/src/user/dtos/create-user.dto.ts
+++ b/src/user/dtos/create-user.dto.ts
@@ -25,6 +25,11 @@ export class CreateUserDto {
   @ApiProperty({ type: String })
   partnerAccessCode?: string;
 
+  @IsOptional()
+  @IsString()
+  @ApiProperty({ type: String })
+  partnerId?: string;
+
   @IsDefined()
   @IsBoolean()
   @ApiProperty({ type: Boolean })

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -152,7 +152,7 @@ describe('UserService', () => {
     });
     it('when supplied with user dto and partnerId but no partner access code, it should return a user with partner access', async () => {
       jest
-        .spyOn(mockPartnerAccessService, 'assignPartnerAccessOnSignup')
+        .spyOn(mockPartnerAccessService, 'assignPartnerAccessOnSignupWithoutCode')
         .mockResolvedValue(mockPartnerAccessEntity);
       jest.spyOn(mockPartnerRepository, 'findOne').mockResolvedValue(mockPartnerEntity);
       const user = await service.createUser({

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -169,6 +169,50 @@ describe('UserService', () => {
       const user = await service.createUser({ ...createUserDto, partnerAccessCode: '123456' });
       expect(user.partnerAccesses).toBeUndefined();
     });
+    it('when supplied with user dto and partnerId but no partner, it should return a user with partner access', async () => {
+      const now = new Date();
+
+      jest.spyOn(mockPartnerAccessService, 'assignPartnerAccessOnSignup').mockResolvedValue({
+        partner: { id: '123' } as PartnerEntity,
+        userId: '123',
+        partnerId: '123',
+        accessCode: '123456',
+        therapySession: [],
+        featureLiveChat: true,
+        featureTherapy: true,
+        therapySessionsRedeemed: 0,
+        therapySessionsRemaining: 6,
+        id: 'id',
+        active: true,
+        activatedAt: now,
+        updatedAt: now,
+        createdAt: now,
+      } as PartnerAccessEntity);
+      jest
+        .spyOn(mockPartnerRepository, 'findOne')
+        .mockResolvedValue({ id: '123', name: 'Bumble' } as PartnerEntity);
+      const user = await service.createUser({
+        ...createUserDto,
+        partnerAccessCode: '123456',
+        partnerId: '123',
+      });
+      expect(user.partnerAccesses).toEqual([
+        {
+          accessCode: '123456',
+          activatedAt: now,
+          active: true,
+          createdAt: now,
+          featureLiveChat: true,
+          featureTherapy: true,
+          id: 'id',
+          partner: { id: '123' },
+          therapySessions: [],
+          therapySessionsRedeemed: 0,
+          therapySessionsRemaining: 6,
+          updatedAt: now,
+        },
+      ]);
+    });
   });
   describe('getUser', () => {
     it('when supplied a firebase user dto, it should return a user', async () => {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -32,8 +32,15 @@ export class UserService {
   ) {}
 
   public async createUser(createUserDto: CreateUserDto): Promise<GetUserDto> {
-    const { name, email, firebaseUid, partnerAccessCode, contactPermission, signUpLanguage } =
-      createUserDto;
+    const {
+      name,
+      email,
+      firebaseUid,
+      partnerAccessCode,
+      contactPermission,
+      signUpLanguage,
+      partnerId,
+    } = createUserDto;
     const createUserObject = this.userRepository.create({
       name,
       email,
@@ -45,12 +52,14 @@ export class UserService {
     try {
       const createUserResponse = await this.userRepository.save(createUserObject);
 
-      const partnerAccessResponse: PartnerAccessEntity | undefined = partnerAccessCode
-        ? await this.partnerAccessService.assignPartnerAccessOnSignup(
-            partnerAccessCode,
-            createUserResponse.id,
-          )
-        : undefined;
+      const partnerAccessResponse: PartnerAccessEntity | undefined =
+        partnerAccessCode || partnerId
+          ? await this.partnerAccessService.assignPartnerAccessOnSignup({
+              partnerAccessCode,
+              userId: createUserResponse.id,
+              partnerId,
+            })
+          : undefined;
 
       const partnerResponse: PartnerEntity | undefined = partnerAccessResponse
         ? await this.partnerRepository.findOne({

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,10 +1,7 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { createCrispProfileData } from 'src/api/crisp/utils/createCrispProfileData';
-import { PartnerAccessEntity } from 'src/entities/partner-access.entity';
-import { PartnerEntity } from 'src/entities/partner.entity';
 import { IFirebaseUser } from 'src/firebase/firebase-user.interface';
-import { IPartnerAccessWithPartner } from 'src/partner-access/partner-access.interface';
 import {
   addCrispProfile,
   deleteCrispProfile,
@@ -12,7 +9,6 @@ import {
 } from '../api/crisp/crisp-api';
 import { AuthService } from '../auth/auth.service';
 import { PartnerAccessService } from '../partner-access/partner-access.service';
-import { PartnerRepository } from '../partner/partner.repository';
 import { formatUserObject } from '../utils/serialize';
 import { generateRandomString } from '../utils/utils';
 import { CreateUserDto } from './dtos/create-user.dto';
@@ -25,8 +21,6 @@ export class UserService {
   constructor(
     @InjectRepository(UserRepository)
     private userRepository: UserRepository,
-    @InjectRepository(PartnerRepository)
-    private partnerRepository: PartnerRepository,
     private readonly partnerAccessService: PartnerAccessService,
     private readonly authService: AuthService,
   ) {}
@@ -51,8 +45,8 @@ export class UserService {
 
     try {
       const createUserResponse = await this.userRepository.save(createUserObject);
-
-      const partnerAccessResponse: PartnerAccessEntity | undefined =
+      // Only assign Partner access code if partner access or partner id is supplied
+      const partnerAccessWithPartner =
         partnerAccessCode || partnerId
           ? await this.partnerAccessService.assignPartnerAccessOnSignup({
               partnerAccessCode,
@@ -61,16 +55,7 @@ export class UserService {
             })
           : undefined;
 
-      const partnerResponse: PartnerEntity | undefined = partnerAccessResponse
-        ? await this.partnerRepository.findOne({
-            id: partnerAccessResponse.partnerId,
-          })
-        : undefined;
-
-      const partnerAccessWithPartner: IPartnerAccessWithPartner | undefined =
-        partnerResponse && partnerAccessResponse
-          ? { ...partnerAccessResponse, partner: partnerResponse }
-          : undefined;
+      // partner segment is for crisp API
       const partnerSegment = partnerAccessWithPartner
         ? partnerAccessWithPartner.partner.name
         : 'public';
@@ -89,10 +74,10 @@ export class UserService {
         createUserResponse.email,
       );
 
-      return partnerAccessResponse && partnerResponse
+      return partnerAccessWithPartner
         ? formatUserObject({
             ...createUserResponse,
-            ...(partnerAccessResponse ? { partnerAccess: [partnerAccessResponse] } : {}),
+            ...(partnerAccessWithPartner ? { partnerAccess: [partnerAccessWithPartner] } : {}),
           })
         : { user: createUserResponse };
     } catch (error) {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -46,14 +46,17 @@ export class UserService {
     try {
       const createUserResponse = await this.userRepository.save(createUserObject);
       // Only assign Partner access code if partner access or partner id is supplied
-      const partnerAccessWithPartner =
-        partnerAccessCode || partnerId
-          ? await this.partnerAccessService.assignPartnerAccessOnSignup({
-              partnerAccessCode,
-              userId: createUserResponse.id,
-              partnerId,
-            })
-          : undefined;
+      const partnerAccessWithPartner = partnerAccessCode
+        ? await this.partnerAccessService.assignPartnerAccessOnSignup({
+            partnerAccessCode,
+            userId: createUserResponse.id,
+          })
+        : partnerId
+        ? await this.partnerAccessService.assignPartnerAccessOnSignupWithoutCode({
+            partnerId,
+            userId: createUserResponse.id,
+          })
+        : undefined;
 
       // partner segment is for crisp API
       const partnerSegment = partnerAccessWithPartner

--- a/src/webhooks/webhooks.service.spec.ts
+++ b/src/webhooks/webhooks.service.spec.ts
@@ -413,12 +413,7 @@ describe('WebhooksService', () => {
           ...{ action: SIMPLYBOOK_ACTION_ENUM.NEW_BOOKING },
         }),
       ).resolves.toHaveProperty('action', SIMPLYBOOK_ACTION_ENUM.NEW_BOOKING);
-      expect(partnerAccessSaveSpy).toBeCalledWith({
-        featureTherapy: true,
-        id: 'pa1',
-        therapySessionsRedeemed: 1,
-        therapySessionsRemaining: 5,
-      });
+      expect(partnerAccessSaveSpy).toBeCalledWith(mockPartnerAccessEntity);
     });
     it('should not update partner access when user updates booking', async () => {
       const partnerAccessSaveSpy = jest.spyOn(mockedPartnerAccessRepository, 'save');

--- a/test/utils/mockData.ts
+++ b/test/utils/mockData.ts
@@ -168,13 +168,24 @@ export const mockSimplybookBodyBase: SimplybookBodyDto = {
   service_provider_name: 'therapist@test.com',
 };
 
+export const mockPartnerEntity = { name: 'Bumble', id: 'partnerId' } as PartnerEntity;
+
 export const mockPartnerAccessEntity = {
   id: 'pa1',
   therapySessionsRemaining: 5,
   therapySessionsRedeemed: 1,
   featureTherapy: true,
+  featureLiveChat: true,
+  accessCode: '123456',
+  partner: mockPartnerEntity,
+  partnerAdmin: null,
+  partnerAdminId: null,
+  createdAt: new Date(),
+  activatedAt: new Date(),
+  therapySession: [],
+  updatedAt: new Date(),
+  active: true,
 } as PartnerAccessEntity;
-export const mockPartnerEntity = { name: 'Bumble' } as PartnerEntity;
 
 export const mockEmailCampaignEntity: EmailCampaignEntity = {
   email: 'test@test.com',

--- a/test/utils/mockedServices.ts
+++ b/test/utils/mockedServices.ts
@@ -11,6 +11,7 @@ import { SessionEntity } from 'src/entities/session.entity';
 import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
 import { UserEntity } from 'src/entities/user.entity';
 import { PartnerAccessRepository } from 'src/partner-access/partner-access.repository';
+import { PartnerRepository } from 'src/partner/partner.repository';
 import { SessionRepository } from 'src/session/session.repository';
 import { CreateUserDto } from 'src/user/dtos/create-user.dto';
 import { UpdateUserDto } from 'src/user/dtos/update-user.dto';
@@ -99,6 +100,7 @@ export const mockUserRepositoryMethodsFactory = {
 };
 
 export const mockPartnerAccessRepositoryMethods: PartialFuncReturn<PartnerAccessRepository> = {
+  createQueryBuilder: createQueryBuilderMock(),
   create: (dto) => {
     return {
       ...mockPartnerAccessEntity,
@@ -112,6 +114,22 @@ export const mockPartnerAccessRepositoryMethods: PartialFuncReturn<PartnerAccess
     return [{ ...mockPartnerAccessEntity, ...(arg ? { ...arg } : {}) }] as PartnerAccessEntity[];
   },
   save: async (arg) => arg as PartnerAccessEntity,
+};
+
+export const mockPartnerRepositoryMethods: PartialFuncReturn<PartnerRepository> = {
+  create: (dto) => {
+    return {
+      ...mockPartnerEntity,
+      ...dto,
+    } as PartnerEntity;
+  },
+  findOne: async (arg) => {
+    return { ...mockPartnerEntity, ...(arg ? { ...arg } : {}) } as PartnerEntity;
+  },
+  find: async (arg) => {
+    return [{ ...mockPartnerEntity, ...(arg ? { ...arg } : {}) }] as PartnerEntity[];
+  },
+  save: async (arg) => arg as PartnerEntity,
 };
 
 export const mockSlackMessageClientMethods: PartialFuncReturn<SlackMessageClient> = {


### PR DESCRIPTION
Adaptation of current create user endpoint to allow adding partner users with partnerId rather than access code. Also note issue around storing what a base partnerAccess is. Let me know your thoughts