### PR TITLE
Add created and updated dates to subscription table

### DIFF
--- a/src/entities/base.entity.ts
+++ b/src/entities/base.entity.ts
@@ -1,6 +1,6 @@
 import { CreateDateColumn, UpdateDateColumn } from 'typeorm';
 
-export abstract class BaseEntity {
+export abstract class BaseBloomEntity {
   @CreateDateColumn({ type: 'timestamptz', default: () => 'CURRENT_TIMESTAMP' })
   createdAt: Date;
 

--- a/src/entities/course-partner.entity.ts
+++ b/src/entities/course-partner.entity.ts
@@ -1,11 +1,11 @@
 import { Column, Entity, JoinTable, ManyToOne, PrimaryGeneratedColumn, Unique } from 'typeorm';
-import { BaseEntity } from './base.entity';
+import { BaseBloomEntity } from './base.entity';
 import { CourseEntity } from './course.entity';
 import { PartnerEntity } from './partner.entity';
 
 @Entity({ name: 'course_partner' })
 @Unique('course_partner_index_name', ['partnerId', 'courseId'])
-export class CoursePartnerEntity extends BaseEntity {
+export class CoursePartnerEntity extends BaseBloomEntity {
   @PrimaryGeneratedColumn('uuid', { name: 'coursePartnerId' })
   id: string;
 

--- a/src/entities/course-user.entity.ts
+++ b/src/entities/course-user.entity.ts
@@ -7,14 +7,14 @@ import {
   PrimaryGeneratedColumn,
   Unique,
 } from 'typeorm';
-import { BaseEntity } from './base.entity';
+import { BaseBloomEntity } from './base.entity';
 import { CourseEntity } from './course.entity';
 import { SessionUserEntity } from './session-user.entity';
 import { UserEntity } from './user.entity';
 
 @Entity({ name: 'course_user' })
 @Unique('course_user_index_name', ['userId', 'courseId'])
-export class CourseUserEntity extends BaseEntity {
+export class CourseUserEntity extends BaseBloomEntity {
   @PrimaryGeneratedColumn('uuid', { name: 'courseUserId' })
   id: string;
 

--- a/src/entities/course.entity.ts
+++ b/src/entities/course.entity.ts
@@ -1,12 +1,12 @@
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { STORYBLOK_STORY_STATUS_ENUM } from '../utils/constants';
-import { BaseEntity } from './base.entity';
+import { BaseBloomEntity } from './base.entity';
 import { CoursePartnerEntity } from './course-partner.entity';
 import { CourseUserEntity } from './course-user.entity';
 import { SessionEntity } from './session.entity';
 
 @Entity({ name: 'course' })
-export class CourseEntity extends BaseEntity {
+export class CourseEntity extends BaseBloomEntity {
   @PrimaryGeneratedColumn('uuid', { name: 'courseId' })
   id: string;
 

--- a/src/entities/email-campaign.entity.ts
+++ b/src/entities/email-campaign.entity.ts
@@ -1,10 +1,10 @@
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 import { CAMPAIGN_TYPE } from 'src/utils/constants';
-import { BaseEntity } from './base.entity';
+import { BaseBloomEntity } from './base.entity';
 
 @Entity({ name: 'email_campaign' })
-export class EmailCampaignEntity extends BaseEntity {
+export class EmailCampaignEntity extends BaseBloomEntity {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 

--- a/src/entities/partner-access.entity.ts
+++ b/src/entities/partner-access.entity.ts
@@ -10,11 +10,11 @@ import {
 import { PartnerAdminEntity } from '../entities/partner-admin.entity';
 import { PartnerEntity } from '../entities/partner.entity';
 import { UserEntity } from '../entities/user.entity';
-import { BaseEntity } from './base.entity';
+import { BaseBloomEntity } from './base.entity';
 import { TherapySessionEntity } from './therapy-session.entity';
 
 @Entity({ name: 'partner_access' })
-export class PartnerAccessEntity extends BaseEntity {
+export class PartnerAccessEntity extends BaseBloomEntity {
   @PrimaryGeneratedColumn('uuid', { name: 'partnerAccessId' })
   id: string;
 

--- a/src/entities/partner-admin.entity.ts
+++ b/src/entities/partner-admin.entity.ts
@@ -1,5 +1,3 @@
-import { PartnerEntity } from '../entities/partner.entity';
-import { UserEntity } from '../entities/user.entity';
 import {
   Column,
   Entity,
@@ -10,11 +8,13 @@ import {
   OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-import { BaseEntity } from './base.entity';
+import { PartnerEntity } from '../entities/partner.entity';
+import { UserEntity } from '../entities/user.entity';
+import { BaseBloomEntity } from './base.entity';
 import { PartnerAccessEntity } from './partner-access.entity';
 
 @Entity({ name: 'partner_admin' })
-export class PartnerAdminEntity extends BaseEntity {
+export class PartnerAdminEntity extends BaseBloomEntity {
   @PrimaryGeneratedColumn('uuid', { name: 'partnerAdminId' })
   id: string;
 

--- a/src/entities/partner.entity.ts
+++ b/src/entities/partner.entity.ts
@@ -1,11 +1,11 @@
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
-import { BaseEntity } from '../entities/base.entity';
+import { BaseBloomEntity } from '../entities/base.entity';
 import { PartnerAccessEntity } from '../entities/partner-access.entity';
 import { PartnerAdminEntity } from '../entities/partner-admin.entity';
 import { CoursePartnerEntity } from './course-partner.entity';
 
 @Entity({ name: 'partner' })
-export class PartnerEntity extends BaseEntity {
+export class PartnerEntity extends BaseBloomEntity {
   @PrimaryGeneratedColumn('uuid', { name: 'partnerId' })
   id: string;
 

--- a/src/entities/session-user.entity.ts
+++ b/src/entities/session-user.entity.ts
@@ -1,11 +1,11 @@
 import { Column, Entity, JoinTable, ManyToOne, PrimaryGeneratedColumn, Unique } from 'typeorm';
-import { BaseEntity } from './base.entity';
+import { BaseBloomEntity } from './base.entity';
 import { CourseUserEntity } from './course-user.entity';
 import { SessionEntity } from './session.entity';
 
 @Entity({ name: 'session_user' })
 @Unique('session_user_index_name', ['courseUserId', 'sessionId'])
-export class SessionUserEntity extends BaseEntity {
+export class SessionUserEntity extends BaseBloomEntity {
   @PrimaryGeneratedColumn('uuid', { name: 'sessionUserId' })
   id: string;
 

--- a/src/entities/session.entity.ts
+++ b/src/entities/session.entity.ts
@@ -1,11 +1,11 @@
 import { Column, Entity, JoinTable, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { STORYBLOK_STORY_STATUS_ENUM } from '../utils/constants';
-import { BaseEntity } from './base.entity';
+import { BaseBloomEntity } from './base.entity';
 import { CourseEntity } from './course.entity';
 import { SessionUserEntity } from './session-user.entity';
 
 @Entity({ name: 'session' })
-export class SessionEntity extends BaseEntity {
+export class SessionEntity extends BaseBloomEntity {
   @PrimaryGeneratedColumn('uuid', { name: 'sessionId' })
   id: string;
 

--- a/src/entities/subscription-user.entity.ts
+++ b/src/entities/subscription-user.entity.ts
@@ -1,10 +1,10 @@
 import { Column, Entity, JoinTable, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
-import { BaseEntity } from './base.entity';
+import { BaseBloomEntity } from './base.entity';
 import { SubscriptionEntity } from './subscription.entity';
 import { UserEntity } from './user.entity';
 
 @Entity({ name: 'subscription_user' })
-export class SubscriptionUserEntity extends BaseEntity {
+export class SubscriptionUserEntity extends BaseBloomEntity {
   @PrimaryGeneratedColumn('uuid', { name: 'subscriptionUserId' })
   id: string;
 

--- a/src/entities/subscription.entity.ts
+++ b/src/entities/subscription.entity.ts
@@ -1,9 +1,9 @@
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
-import { BaseEntity } from './base.entity';
+import { BaseBloomEntity } from './base.entity';
 import { SubscriptionUserEntity } from './subscription-user.entity';
 
 @Entity({ name: 'subscription' })
-export class SubscriptionEntity extends BaseEntity {
+export class SubscriptionEntity extends BaseBloomEntity {
   @PrimaryGeneratedColumn('uuid', { name: 'subscriptionId' })
   id: string;
 

--- a/src/entities/subscription.entity.ts
+++ b/src/entities/subscription.entity.ts
@@ -1,8 +1,7 @@
-import { BaseEntity, Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { BaseEntity } from './base.entity';
 import { SubscriptionUserEntity } from './subscription-user.entity';
 
-// NB: The base entity imported here is wrong. The base entity within the project should be imported.
-// This should be fixed by adding a createdAt and updatedAt column to the subscription table (via migration) at a later date.
 @Entity({ name: 'subscription' })
 export class SubscriptionEntity extends BaseEntity {
   @PrimaryGeneratedColumn('uuid', { name: 'subscriptionId' })

--- a/src/entities/therapy-session.entity.ts
+++ b/src/entities/therapy-session.entity.ts
@@ -1,10 +1,10 @@
 import { Column, Entity, JoinTable, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { SIMPLYBOOK_ACTION_ENUM } from '../utils/constants';
-import { BaseEntity } from './base.entity';
+import { BaseBloomEntity } from './base.entity';
 import { PartnerAccessEntity } from './partner-access.entity';
 
 @Entity({ name: 'therapy_session' })
-export class TherapySessionEntity extends BaseEntity {
+export class TherapySessionEntity extends BaseBloomEntity {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -1,12 +1,12 @@
 import { Column, Entity, Generated, OneToMany, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { PartnerAccessEntity } from '../entities/partner-access.entity';
 import { PartnerAdminEntity } from '../entities/partner-admin.entity';
-import { BaseEntity } from './base.entity';
+import { BaseBloomEntity } from './base.entity';
 import { CourseUserEntity } from './course-user.entity';
 import { SubscriptionUserEntity } from './subscription-user.entity';
 
 @Entity({ name: 'user' })
-export class UserEntity extends BaseEntity {
+export class UserEntity extends BaseBloomEntity {
   @PrimaryGeneratedColumn('uuid', { name: 'userId' })
   id: string;
 

--- a/src/migrations/1675270454467-bloom-backend.ts
+++ b/src/migrations/1675270454467-bloom-backend.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class bloomBackend1675270454467 implements MigrationInterface {
+  name = 'bloomBackend1675270454467';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "subscription" ADD "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscription" ADD "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "subscription" DROP COLUMN "updatedAt"`);
+    await queryRunner.query(`ALTER TABLE "subscription" DROP COLUMN "createdAt"`);
+  }
+}


### PR DESCRIPTION
These were missed out by mistake in the original migration. 

The base entity which brings in these fields automatically has now been renamed to base bloom entity. 

This prevents the type orm base entity from being imported by mistake.