### PR TITLE
Update partner-access table to remove unique user constraint

### DIFF
--- a/src/entities/partner-access.entity.ts
+++ b/src/entities/partner-access.entity.ts
@@ -18,7 +18,7 @@ export class PartnerAccessEntity extends BaseBloomEntity {
   @PrimaryGeneratedColumn('uuid', { name: 'partnerAccessId' })
   id: string;
 
-  @Column({ nullable: true })
+  @Column({ nullable: true, unique: false })
   userId: string;
   @ManyToOne(() => UserEntity, (userEntity) => userEntity.partnerAccess, {
     onDelete: 'CASCADE',

--- a/src/migrations/1680797056762-bloom-backend.ts
+++ b/src/migrations/1680797056762-bloom-backend.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class bloomBackend1680797056762 implements MigrationInterface {
+  name = 'bloomBackend1680797056762';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "partner_access" DROP CONSTRAINT "REL_25e7860a2eec1f9366fcfe3a95"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "partner_access" ADD CONSTRAINT "REL_25e7860a2eec1f9366fcfe3a95" UNIQUE ("userId")`,
+    );
+  }
+}


### PR DESCRIPTION
With this change, the same user should be able to apply multiple codes to their account. 

Note that I generated this migration by hand. The change in the entity file is more for documentation purposes. Typeorm didn't notice the entity change as a schema change (-_-) and so wouldn't create an automated migration. 