### PR TITLE
Fix case sensitive therapy email webhook

### DIFF
--- a/src/webhooks/webhooks.service.ts
+++ b/src/webhooks/webhooks.service.ts
@@ -148,7 +148,10 @@ export class WebhooksService {
   async updatePartnerAccessTherapy(
     simplyBookDto: SimplybookBodyDto,
   ): Promise<TherapySessionEntity> {
-    const { action, client_email, booking_code } = simplyBookDto;
+    const { action, booking_code } = simplyBookDto;
+    // this ensures that the client email can be matched against the db which contains lower case emails
+    const client_email = simplyBookDto.client_email.toLowerCase();
+
     this.logger.log(
       `UpdatePartnerAccessService method initiated for ${action} - ${client_email} - ${booking_code}`,
     );


### PR DESCRIPTION
This fix ensures even if a known user puts in an email with capitals, we can still correctly match them up in the db.