### PR TITLE
[HIGH LEVEL] Update parseAuth method so auth guards to handle error not method

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -38,7 +38,7 @@ export class AuthService {
 
       return decodedToken;
     } catch (err) {
-      throw new UnauthorizedException(err, 'Unauthorized: token is expired or invalid');
+      throw err;
     }
   }
 

--- a/src/partner-admin/partner-admin-auth.guard.spec.ts
+++ b/src/partner-admin/partner-admin-auth.guard.spec.ts
@@ -88,7 +88,9 @@ describe('PartnerAdminAuthGuard', () => {
       await guard.canActivate(context);
       fail('it should not reach here');
     } catch (error) {
-      expect(error).toBe(badAuthMessage);
+      expect(error.message).toBe(
+        `PartnerAdminAuthGuard - Error parsing firebase user: ${badAuthMessage}`,
+      );
     }
   });
 });


### PR DESCRIPTION
- the Unauthorized Exceptioin wrapper was adding filler that was confusing the auth guards. 
- Errors that are thrown are now handled by the auth guard rather than the auth service method. In general we want the controllers and auth guards to put wrappers around the exception and then for the nested methods to pass the error back