### PR TITLE
Add filter to GET partner-access endpoint

### DIFF
--- a/src/partner-access/dtos/get-partner-access.dto.ts
+++ b/src/partner-access/dtos/get-partner-access.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsInt, IsOptional, IsString } from 'class-validator';
+
+export class GetPartnerAccessesDto {
+  @IsBoolean()
+  @IsOptional()
+  @ApiProperty({ type: Boolean })
+  featureLiveChat: boolean;
+
+  @IsBoolean()
+  @IsOptional()
+  @ApiProperty({ type: Boolean })
+  featureTherapy: boolean;
+
+  @IsInt()
+  @IsOptional()
+  @ApiProperty({ type: Number })
+  therapySessionsRemaining: number;
+
+  @IsInt()
+  @IsOptional()
+  @ApiProperty({ type: Number })
+  therapySessionsRedeemed: number;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty({ type: String })
+  accessCode: string;
+}

--- a/src/partner-access/partner-access.controller.ts
+++ b/src/partner-access/partner-access.controller.ts
@@ -9,6 +9,7 @@ import { SuperAdminAuthGuard } from '../partner-admin/super-admin-auth.guard';
 import { GetUserDto } from '../user/dtos/get-user.dto';
 import { ControllerDecorator } from '../utils/controller.decorator';
 import { CreatePartnerAccessDto } from './dtos/create-partner-access.dto';
+import { GetPartnerAccessesDto } from './dtos/get-partner-access.dto';
 import { ValidatePartnerAccessCodeDto } from './dtos/validate-partner-access.dto';
 import { PartnerAccessService } from './partner-access.service';
 
@@ -52,8 +53,11 @@ export class PartnerAccessController {
   })
   @UseGuards(SuperAdminAuthGuard)
   @Get()
-  async getPartnerAccessCodes(): Promise<PartnerAccessEntity[]> {
-    return this.partnerAccessService.getPartnerAccessCodes();
+  @ApiBody({ type: GetPartnerAccessesDto, required: false })
+  async getPartnerAccessCodes(
+    @Body() getPartnerAccessDto: GetPartnerAccessesDto | undefined,
+  ): Promise<PartnerAccessEntity[]> {
+    return this.partnerAccessService.getPartnerAccessCodes(getPartnerAccessDto);
   }
 
   @Post('validate-code')

--- a/src/partner-access/partner-access.service.spec.ts
+++ b/src/partner-access/partner-access.service.spec.ts
@@ -3,12 +3,18 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as crispApi from 'src/api/crisp/crisp-api';
 import { PartnerRepository } from 'src/partner/partner.repository';
 import { GetUserDto } from 'src/user/dtos/get-user.dto';
-import { mockPartnerAccessEntity, mockPartnerEntity, mockUserEntity } from 'test/utils/mockData';
+import {
+  mockPartnerAccessEntity,
+  mockPartnerEntity,
+  mockUserEntity,
+  partnerAccessArray,
+} from 'test/utils/mockData';
 import { mockPartnerRepositoryMethods } from 'test/utils/mockedServices';
 import { Repository } from 'typeorm';
 import { createQueryBuilderMock } from '../../test/utils/mockUtils';
 import { PartnerAccessEntity } from '../entities/partner-access.entity';
 import { CreatePartnerAccessDto } from './dtos/create-partner-access.dto';
+import { GetPartnerAccessesDto } from './dtos/get-partner-access.dto';
 import { PartnerAccessRepository } from './partner-access.repository';
 import { PartnerAccessService } from './partner-access.service';
 
@@ -73,6 +79,7 @@ describe('PartnerAccessService', () => {
                 ...dto,
               };
             },
+            find: jest.fn(() => partnerAccessArray),
             save: jest.fn((arg) => arg),
           })),
         },
@@ -203,6 +210,24 @@ describe('PartnerAccessService', () => {
       expect(partnerAccess.userId).toBe(mockGetUserDto.user.id);
       expect(partnerAccess.featureLiveChat).toBeTruthy();
       expect(partnerAccess.featureTherapy).toBeFalsy();
+    });
+  });
+  describe('getPartnerAccessCodes', () => {
+    it('when no filter dto is supplied, it should return all partner accesses', async () => {
+      const partnerAccesses = await service.getPartnerAccessCodes(undefined);
+      expect(partnerAccesses.length).toBeGreaterThan(0);
+    });
+    it('when a accessCode filter is supplied, it should return all matching accessCodes', async () => {
+      jest
+        .spyOn(repo, 'find')
+        .mockImplementationOnce(async () => [
+          { ...mockPartnerAccessEntity, accessCode: mockPartnerAccessEntity.accessCode + 0 },
+        ]);
+      const partnerAccesses = await service.getPartnerAccessCodes({
+        accessCode: mockPartnerAccessEntity.accessCode + 0,
+      } as GetPartnerAccessesDto);
+
+      expect(partnerAccesses.length).toBe(1);
     });
   });
 });

--- a/src/partner-access/partner-access.service.ts
+++ b/src/partner-access/partner-access.service.ts
@@ -10,6 +10,7 @@ import { PartnerAccessEntity } from '../entities/partner-access.entity';
 import { GetUserDto } from '../user/dtos/get-user.dto';
 import { PartnerAccessCodeStatusEnum } from '../utils/constants';
 import { CreatePartnerAccessDto } from './dtos/create-partner-access.dto';
+import { GetPartnerAccessesDto } from './dtos/get-partner-access.dto';
 import { PartnerAccessRepository } from './partner-access.repository';
 
 // TODO storing base service minimum here but this might need to be a config setup eventually
@@ -87,11 +88,13 @@ export class PartnerAccessService {
     return partnerAccess;
   }
 
-  async getPartnerAccessCodes(): Promise<PartnerAccessEntity[]> {
-    return await this.partnerAccessRepository
-      .createQueryBuilder('partnerAccess')
-      .leftJoinAndSelect('partnerAccess.partner', 'partner')
-      .getMany();
+  async getPartnerAccessCodes(
+    partnerAccessDto: GetPartnerAccessesDto | undefined,
+  ): Promise<PartnerAccessEntity[]> {
+    return await this.partnerAccessRepository.find({
+      relations: ['partner'],
+      where: partnerAccessDto ? partnerAccessDto : undefined,
+    });
   }
 
   async assignPartnerAccessOnSignup(

--- a/test/utils/mockData.ts
+++ b/test/utils/mockData.ts
@@ -236,3 +236,13 @@ export const mockPartnerFeatureEntity = {
 export const mockUserRecord = {
   uid: 'FirebaseUuid',
 } as UserRecord;
+
+export const partnerAccessArray = Array.from(
+  [
+    mockPartnerAccessEntity,
+    mockPartnerAccessEntity,
+    mockPartnerAccessEntity,
+    mockPartnerAccessEntity,
+  ],
+  (x, index) => ({ ...mockPartnerAccessEntity, accessCode: x.accessCode + index }),
+);


### PR DESCRIPTION
I had a request to check multiple access codes to see why they weren't working. Instead of spending the time manually looking at each entry - I decided to update the GET endpoint to check them as it only would have taken a little longer than the manual checks and writing the SQL. 
- adding an optional filter object to the GET partner-access endpoint. It will remain superadmin authguarded 
- 2 service tests to safeguard the endpoint
- This potentially might be useful for our new partner access update UI as well