### PR TITLE
Remove Jest collectCoverageFrom in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,9 +97,6 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node",
     "moduleDirectories": [
@@ -108,6 +105,11 @@
     ],
     "modulePaths": [
       "<rootDir>"
+    ],
+    "testPathIgnorePatterns": [
+      "src/migrations",
+      "dist",
+      "coverage"
     ]
   }
 }


### PR DESCRIPTION
- It was saying we had 11 percent code coverage because it was including unecessary files. I've removed the collectCoverageFrom because it was including all files.