### PR TITLE
Therapy Session and email feedback Refactor 

### DIFF
--- a/src/api/simplybook/simplybook-api.ts
+++ b/src/api/simplybook/simplybook-api.ts
@@ -1,9 +1,10 @@
 import { Logger } from '@nestjs/common';
 import axios from 'axios';
+import format from 'date-fns/format';
 
 import { simplybookCompanyName, simplybookCredentials } from 'src/utils/constants';
 
-type BookingReponse = {
+type BookingResponse = {
   client: {
     name: string;
     email: string;
@@ -17,7 +18,6 @@ export type BookingInfo = {
   date: Date;
 };
 
-const DATE_FORMAT_LENGTH = 'YYYY-mm-dd'.length;
 const SIMPLYBOOK_API_BASE_URL = 'https://user-api-v2.simplybook.me/admin';
 const LOGGER = new Logger('SimplybookAPI');
 
@@ -38,10 +38,10 @@ const getAuthToken: () => Promise<string> = async () => {
   }
 };
 
-const queryBookingsForDate: (date: Date) => Promise<BookingReponse[]> = async (date: Date) => {
+const queryBookingsForDate: (date: Date) => Promise<BookingResponse[]> = async (date: Date) => {
   const token = await getAuthToken();
 
-  const simplybookFilterDateString = date.toISOString().substring(0, DATE_FORMAT_LENGTH);
+  const simplybookFilterDateString = format(date, 'yyyy-MM-dd');
 
   try {
     const bookingsResponse = await axios.get(
@@ -65,7 +65,7 @@ const queryBookingsForDate: (date: Date) => Promise<BookingReponse[]> = async (d
 
 export const getBookingsForDate: (date: Date) => Promise<BookingInfo[]> = async (date: Date) => {
   try {
-    const bookings: BookingReponse[] = await queryBookingsForDate(date);
+    const bookings: BookingResponse[] = await queryBookingsForDate(date);
 
     return bookings.map((booking) => ({
       clientEmail: booking.client.email,

--- a/src/entities/therapy-session.entity.ts
+++ b/src/entities/therapy-session.entity.ts
@@ -2,6 +2,7 @@ import { Column, Entity, JoinTable, ManyToOne, PrimaryGeneratedColumn } from 'ty
 import { SIMPLYBOOK_ACTION_ENUM } from '../utils/constants';
 import { BaseBloomEntity } from './base.entity';
 import { PartnerAccessEntity } from './partner-access.entity';
+import { UserEntity } from './user.entity';
 
 @Entity({ name: 'therapy_session' })
 export class TherapySessionEntity extends BaseBloomEntity {
@@ -49,4 +50,13 @@ export class TherapySessionEntity extends BaseBloomEntity {
   @ManyToOne(() => PartnerAccessEntity, (partnerAccess) => partnerAccess.therapySession)
   @JoinTable({ name: 'partner_access', joinColumn: { name: 'partnerAccessId' } })
   partnerAccess: PartnerAccessEntity;
+
+  @Column({ nullable: true })
+  userId: string;
+
+  @ManyToOne(() => UserEntity, (user) => user.therapySession, {
+    onDelete: 'CASCADE',
+  })
+  @JoinTable({ name: 'user', joinColumn: { name: 'userId' } })
+  user: UserEntity;
 }

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -4,6 +4,7 @@ import { PartnerAdminEntity } from '../entities/partner-admin.entity';
 import { BaseBloomEntity } from './base.entity';
 import { CourseUserEntity } from './course-user.entity';
 import { SubscriptionUserEntity } from './subscription-user.entity';
+import { TherapySessionEntity } from './therapy-session.entity';
 
 @Entity({ name: 'user' })
 export class UserEntity extends BaseBloomEntity {
@@ -42,6 +43,9 @@ export class UserEntity extends BaseBloomEntity {
 
   @OneToMany(() => SubscriptionUserEntity, (subscriptionUser) => subscriptionUser.user)
   subscriptionUser: SubscriptionUserEntity[];
+
+  @OneToMany(() => TherapySessionEntity, (therapySession) => therapySession.user)
+  therapySession: TherapySessionEntity[];
 
   @Column({ unique: true })
   @Generated('uuid')

--- a/src/migrations/1695059293020-bloom-backend.ts
+++ b/src/migrations/1695059293020-bloom-backend.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class bloomBackend1695059293020 implements MigrationInterface {
+  name = 'bloomBackend1695059293020';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "therapy_session" ADD "userId" uuid`);
+    await queryRunner.query(
+      `ALTER TABLE "therapy_session" ADD CONSTRAINT "FK_58700a8a5d47651d0e895a86b4e" FOREIGN KEY ("userId") REFERENCES "user"("userId") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "therapy_session" DROP CONSTRAINT "FK_58700a8a5d47651d0e895a86b4e"`,
+    );
+    await queryRunner.query(`ALTER TABLE "therapy_session" DROP COLUMN "userId"`);
+  }
+}

--- a/src/partner-access/dtos/zapier-body.dto.ts
+++ b/src/partner-access/dtos/zapier-body.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsDefined, IsEmail, IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { SIMPLYBOOK_ACTION_ENUM } from '../../utils/constants';
 
-export class SimplybookBodyDto {
+export class ZapierSimplybookBodyDto {
   @IsNotEmpty()
   @IsString()
   @IsDefined()
@@ -20,7 +20,7 @@ export class SimplybookBodyDto {
   @IsDefined()
   @IsNotEmpty()
   @ApiProperty({ type: String })
-  client_id: string;
+  client_id: string; // This is userId - not to be confused with the simplybook.client_id
 
   @IsString()
   @IsOptional()

--- a/src/partner-admin/partner-admin-auth.guard.spec.ts
+++ b/src/partner-admin/partner-admin-auth.guard.spec.ts
@@ -24,6 +24,7 @@ const userEntity: UserEntity = {
   courseUser: [],
   signUpLanguage: 'en',
   subscriptionUser: [],
+  therapySession: [],
 };
 describe('PartnerAdminAuthGuard', () => {
   let guard: PartnerAdminAuthGuard;

--- a/src/utils/serialize.spec.ts
+++ b/src/utils/serialize.spec.ts
@@ -19,6 +19,7 @@ describe('Serialize', () => {
         serviceProviderEmail: 'therapist@test.com',
         serviceProviderName: 'therapist@test.com',
         startDateTime: new Date('2022-09-12T07:30:00+0000'),
+        userId: mockSimplybookBodyBase.client_id,
       });
     });
   });

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -6,7 +6,7 @@ import { PartnerAccessEntity } from '../entities/partner-access.entity';
 import { SubscriptionUserEntity } from '../entities/subscription-user.entity';
 import { TherapySessionEntity } from '../entities/therapy-session.entity';
 import { UserEntity } from '../entities/user.entity';
-import { SimplybookBodyDto } from '../partner-access/dtos/zapier-body.dto';
+import { ZapierSimplybookBodyDto } from '../partner-access/dtos/zapier-body.dto';
 import { ISubscriptionUser } from '../subscription-user/subscription-user.interface';
 import { GetUserDto } from '../user/dtos/get-user.dto';
 
@@ -124,7 +124,7 @@ export const formatPartnerObject = (partnerObject: PartnerEntity): IPartner => {
 };
 
 export const formatTherapySessionObject = (
-  therapySession: SimplybookBodyDto,
+  therapySession: ZapierSimplybookBodyDto,
   partnerAccessId: string,
 ): Partial<TherapySessionEntity> => {
   return {
@@ -141,6 +141,7 @@ export const formatTherapySessionObject = (
     rescheduledFrom: null,
     completedAt: null,
     partnerAccessId,
+    userId: therapySession.client_id,
   };
 };
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,5 @@
 import { webcrypto } from 'crypto';
+import { add } from 'date-fns';
 const crypto = webcrypto as unknown as Crypto;
 
 export const generateRandomString = (length: number) => {
@@ -14,4 +15,4 @@ export const generateRandomString = (length: number) => {
     .join('');
 };
 
-export const getYesterdaysDate = () => new Date(new Date().setDate(new Date().getDate() - 1));
+export const getYesterdaysDate = () => add(new Date(), { days: 1 });

--- a/src/webhooks/webhooks.controller.ts
+++ b/src/webhooks/webhooks.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Logger, Post, UseGuards } from '@nestjs/common';
 import { ApiBody, ApiTags } from '@nestjs/swagger';
 import { ControllerDecorator } from 'src/utils/controller.decorator';
-import { SimplybookBodyDto } from '../partner-access/dtos/zapier-body.dto';
+import { ZapierSimplybookBodyDto } from '../partner-access/dtos/zapier-body.dto';
 import { ZapierAuthGuard } from '../partner-access/zapier-auth.guard';
 import { StoryDto } from './dto/story.dto';
 import { WebhooksService } from './webhooks.service';
@@ -15,8 +15,10 @@ export class WebhooksController {
 
   @UseGuards(ZapierAuthGuard)
   @Post('simplybook')
-  @ApiBody({ type: SimplybookBodyDto })
-  async updatePartnerAccessTherapy(@Body() simplybookBodyDto: SimplybookBodyDto): Promise<string> {
+  @ApiBody({ type: ZapierSimplybookBodyDto })
+  async updatePartnerAccessTherapy(
+    @Body() simplybookBodyDto: ZapierSimplybookBodyDto,
+  ): Promise<string> {
     const updatedPartnerAccessTherapy = await this.webhooksService.updatePartnerAccessTherapy(
       simplybookBodyDto,
     );

--- a/src/webhooks/webhooks.service.spec.ts
+++ b/src/webhooks/webhooks.service.spec.ts
@@ -7,6 +7,7 @@ import { CoursePartnerService } from 'src/course-partner/course-partner.service'
 import { CourseRepository } from 'src/course/course.repository';
 import { CourseEntity } from 'src/entities/course.entity';
 import { SessionEntity } from 'src/entities/session.entity';
+import { UserEntity } from 'src/entities/user.entity';
 import { PartnerAccessRepository } from 'src/partner-access/partner-access.repository';
 import { PartnerAdminRepository } from 'src/partner-admin/partner-admin.repository';
 import { PartnerRepository } from 'src/partner/partner.repository';
@@ -540,6 +541,20 @@ describe('WebhooksService', () => {
       const sentEmails = await service.sendFirstTherapySessionFeedbackEmail();
       expect(sentEmails).toBe(
         `First therapy session feedback emails sent to 1 client(s) for date: ${getYesterdaysDate().toLocaleDateString()}`,
+      );
+    });
+    it('should only send bookings to those who have signed up in english', async () => {
+      jest.spyOn(mockedEmailCampaignRepository, 'find').mockImplementationOnce(async () => {
+        return [];
+      });
+      jest
+        .spyOn(mockedTherapySessionRepository, 'findOneOrFail')
+        .mockImplementationOnce(async () => {
+          return { ...mockTherapySessionEntity, user: { signUpLanguage: 'fr' } as UserEntity };
+        });
+      const sentEmails = await service.sendFirstTherapySessionFeedbackEmail();
+      expect(sentEmails).toBe(
+        `First therapy session feedback emails sent to 0 client(s) for date: ${getYesterdaysDate().toLocaleDateString()}`,
       );
     });
   });

--- a/test/utils/mockData.ts
+++ b/test/utils/mockData.ts
@@ -10,7 +10,7 @@ import { SessionEntity } from 'src/entities/session.entity';
 import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
 import { UserEntity } from 'src/entities/user.entity';
 import { IFirebaseUser } from 'src/firebase/firebase-user.interface';
-import { SimplybookBodyDto } from 'src/partner-access/dtos/zapier-body.dto';
+import { ZapierSimplybookBodyDto } from 'src/partner-access/dtos/zapier-body.dto';
 import {
   CAMPAIGN_TYPE,
   SIMPLYBOOK_ACTION_ENUM,
@@ -137,6 +137,7 @@ export const mockUserEntity: UserEntity = {
   name: 'name',
   signUpLanguage: 'en',
   subscriptionUser: [],
+  therapySession: [],
 };
 
 export const mockTherapySessionEntity = {
@@ -158,9 +159,11 @@ export const mockTherapySessionEntity = {
   rescheduledFrom: null,
   completedAt: null,
   id: 'ts1',
+  userId: 'userId',
+  user: { signUpLanguage: 'en' } as UserEntity,
 } as TherapySessionEntity;
 
-export const mockSimplybookBodyBase: SimplybookBodyDto = {
+export const mockSimplybookBodyBase: ZapierSimplybookBodyDto = {
   action: SIMPLYBOOK_ACTION_ENUM.UPDATED_BOOKING,
   start_date_time: '2022-09-12T07:30:00+0000',
   end_date_time: '2022-09-12T08:30:00+0000',

--- a/test/utils/mockedServices.ts
+++ b/test/utils/mockedServices.ts
@@ -73,6 +73,9 @@ export const mockTherapySessionRepositoryMethods: PartialFuncReturn<TherapySessi
   findOne: async (arg) => {
     return { ...mockTherapySessionEntity, ...(arg ? arg : {}) } as TherapySessionEntity;
   },
+  findOneOrFail: async (arg) => {
+    return { ...mockTherapySessionEntity, ...(arg ? arg : {}) } as TherapySessionEntity;
+  },
   save: async (arg) => arg as TherapySessionEntity,
 };
 


### PR DESCRIPTION
- Migration for adding user id to therapy session table 
- Adding userId to tests etc 
- Changed the used of client_id to userId to not confuse the difference between Zapiers usage of client_id from the zap and simplybooks client_id. 
- Don't send emails to non english users
- Use date fns where appropriate