### PR TITLE
feat: enable GET /users to query by partnerAccess.featureTherapy

### DIFF
--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -382,7 +382,7 @@ export class UserService {
     }
   }
   public async getUsers(
-    filters: { email?: string; partnerAccess?: { userId: string } },
+    filters: { email?: string; partnerAccess?: { userId: string; featureTherapy: boolean } },
     relations: Array<string>,
     fields: Array<string>,
     limit: number,
@@ -397,6 +397,12 @@ export class UserService {
       query.andWhere('partnerAccess.userId IS NOT NULL');
     }
 
+    if (filters.partnerAccess?.featureTherapy) {
+      query.andWhere('partnerAccess.featureTherapy = :featureTherapy', {
+        featureTherapy: filters.partnerAccess.featureTherapy,
+      });
+    }
+
     if (filters.email) {
       query.andWhere('user.email ILike :email', { email: `%${filters.email}%` });
     }
@@ -407,7 +413,6 @@ export class UserService {
 
     const queryResult = await query.getMany();
     const formattedUsers = queryResult.map((user) => formatGetUsersObject(user));
-
     return formattedUsers;
   }
 }


### PR DESCRIPTION
### Issue ticket link / number:
NA/ in notion

### What changes did you make?
- allow GET /users search criteria to be queried with `partnerAccess: {"featureTherapy": true }`

### Why did you make the changes?
- Enable the frontend to only get users that had therapySession enabled partnerAccess codes
