### PR TITLE
fix: correcting entity on delete cascades

### DIFF
--- a/src/entities/course-partner.entity.ts
+++ b/src/entities/course-partner.entity.ts
@@ -11,13 +11,13 @@ export class CoursePartnerEntity extends BaseBloomEntity {
 
   @Column({ nullable: true })
   partnerId: string;
-  @ManyToOne(() => PartnerEntity, (partnerEntity) => partnerEntity.partner)
+  @ManyToOne(() => PartnerEntity, (partnerEntity) => partnerEntity.partner, { onDelete: 'CASCADE' })
   @JoinTable({ name: 'partner', joinColumn: { name: 'partnerId' } })
   partner: PartnerEntity;
 
   @Column()
   courseId: string;
-  @ManyToOne(() => CourseEntity, (courseEntity) => courseEntity.courseUser)
+  @ManyToOne(() => CourseEntity, (courseEntity) => courseEntity.courseUser, { onDelete: 'CASCADE' })
   @JoinTable({ name: 'course', joinColumn: { name: 'courseId' } })
   course: CourseEntity;
 

--- a/src/entities/course-user.entity.ts
+++ b/src/entities/course-user.entity.ts
@@ -26,7 +26,7 @@ export class CourseUserEntity extends BaseBloomEntity {
 
   @Column()
   userId: string;
-  @ManyToOne(() => UserEntity, (userEntity) => userEntity.courseUser)
+  @ManyToOne(() => UserEntity, (userEntity) => userEntity.courseUser, { onDelete: 'CASCADE' })
   @JoinTable({ name: 'user', joinColumn: { name: 'userId' } })
   user: UserEntity;
 
@@ -37,6 +37,8 @@ export class CourseUserEntity extends BaseBloomEntity {
   @JoinTable({ name: 'course', joinColumn: { name: 'courseId' } })
   course: CourseEntity;
 
-  @OneToMany(() => SessionUserEntity, (sessionUserEntity) => sessionUserEntity.courseUser)
+  @OneToMany(() => SessionUserEntity, (sessionUserEntity) => sessionUserEntity.courseUser, {
+    cascade: true,
+  })
   sessionUser: SessionUserEntity[];
 }

--- a/src/entities/course.entity.ts
+++ b/src/entities/course.entity.ts
@@ -33,12 +33,12 @@ export class CourseEntity extends BaseBloomEntity {
   })
   storyblokUuid: string;
 
-  @OneToMany(() => SessionEntity, (sessionEntity) => sessionEntity.course)
+  @OneToMany(() => SessionEntity, (sessionEntity) => sessionEntity.course, { cascade: true })
   session: SessionEntity[];
 
-  @OneToMany(() => CourseUserEntity, (courseUser) => courseUser.course)
+  @OneToMany(() => CourseUserEntity, (courseUser) => courseUser.course, { cascade: true })
   courseUser: CourseUserEntity[];
 
-  @OneToMany(() => CoursePartnerEntity, (coursePartner) => coursePartner.course)
+  @OneToMany(() => CoursePartnerEntity, (coursePartner) => coursePartner.course, { cascade: true })
   coursePartner: CoursePartnerEntity[];
 }

--- a/src/entities/feature.entity.ts
+++ b/src/entities/feature.entity.ts
@@ -10,6 +10,8 @@ export class FeatureEntity extends BaseBloomEntity {
   @Column({ unique: true })
   name: string;
 
-  @OneToMany(() => PartnerFeatureEntity, (partnerFeature) => partnerFeature.feature)
+  @OneToMany(() => PartnerFeatureEntity, (partnerFeature) => partnerFeature.feature, {
+    cascade: true,
+  })
   partnerFeature: PartnerFeatureEntity[];
 }

--- a/src/entities/partner-access.entity.ts
+++ b/src/entities/partner-access.entity.ts
@@ -28,7 +28,9 @@ export class PartnerAccessEntity extends BaseBloomEntity {
 
   @Column()
   partnerId: string;
-  @ManyToOne(() => PartnerEntity, (partnerEntity) => partnerEntity.partnerAccess)
+  @ManyToOne(() => PartnerEntity, (partnerEntity) => partnerEntity.partnerAccess, {
+    onDelete: 'CASCADE',
+  })
   @JoinTable({ name: 'partner', joinColumn: { name: 'partnerId' } })
   partner: PartnerEntity;
 
@@ -36,11 +38,14 @@ export class PartnerAccessEntity extends BaseBloomEntity {
   partnerAdminId: string;
   @ManyToOne(() => PartnerAdminEntity, (partnerAdminEntity) => partnerAdminEntity.partnerAccess, {
     eager: true,
+    onDelete: 'SET NULL',
   })
   @JoinTable({ name: 'partner_admin', joinColumn: { name: 'partnerAdminId' } })
   partnerAdmin: PartnerAdminEntity;
 
-  @OneToMany(() => TherapySessionEntity, (therapySession) => therapySession.partnerAccess)
+  @OneToMany(() => TherapySessionEntity, (therapySession) => therapySession.partnerAccess, {
+    cascade: true,
+  })
   therapySession: TherapySessionEntity[];
 
   @Column({ default: true })

--- a/src/entities/partner-admin.entity.ts
+++ b/src/entities/partner-admin.entity.ts
@@ -23,17 +23,22 @@ export class PartnerAdminEntity extends BaseBloomEntity {
   @OneToOne(() => UserEntity, (userEntity) => userEntity.partnerAdmin, {
     primary: true,
     eager: true,
+    onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'userId' })
   user: UserEntity;
 
   @Column()
   partnerId: string;
-  @ManyToOne(() => PartnerEntity, (partnerEntity) => partnerEntity.partnerAdmin)
+  @ManyToOne(() => PartnerEntity, (partnerEntity) => partnerEntity.partnerAdmin, {
+    onDelete: 'CASCADE',
+  })
   @JoinTable({ name: 'partner', joinColumn: { name: 'partnerId' } })
   partner: PartnerEntity;
 
-  @OneToMany(() => PartnerAccessEntity, (partnerAccess) => partnerAccess.partnerAdmin)
+  @OneToMany(() => PartnerAccessEntity, (partnerAccess) => partnerAccess.partnerAdmin, {
+    cascade: true,
+  })
   partnerAccess: PartnerAccessEntity[];
 
   @Column({ type: Boolean, nullable: false, default: true })

--- a/src/entities/partner.entity.ts
+++ b/src/entities/partner.entity.ts
@@ -17,18 +17,22 @@ export class PartnerEntity extends BaseBloomEntity {
   isActive: boolean;
 
   @OneToMany(() => PartnerAdminEntity, (partnerAdminEntity) => partnerAdminEntity.partner, {
-    onDelete: 'CASCADE',
+    cascade: true,
   })
   partnerAdmin: PartnerAdminEntity[];
 
   @OneToMany(() => PartnerAccessEntity, (partnerAccessEntity) => partnerAccessEntity.partner, {
-    onDelete: 'CASCADE',
+    cascade: true,
   })
   partnerAccess: PartnerAccessEntity[];
 
-  @OneToMany(() => CoursePartnerEntity, (coursePartnerEntity) => coursePartnerEntity.partner)
+  @OneToMany(() => CoursePartnerEntity, (coursePartnerEntity) => coursePartnerEntity.partner, {
+    cascade: true,
+  })
   partner: PartnerEntity[];
 
-  @OneToMany(() => PartnerFeatureEntity, (partnerFeatureEntity) => partnerFeatureEntity.partner)
+  @OneToMany(() => PartnerFeatureEntity, (partnerFeatureEntity) => partnerFeatureEntity.partner, {
+    cascade: true,
+  })
   partnerFeature: PartnerFeatureEntity[];
 }

--- a/src/entities/session-user.entity.ts
+++ b/src/entities/session-user.entity.ts
@@ -17,13 +17,17 @@ export class SessionUserEntity extends BaseBloomEntity {
 
   @Column()
   sessionId: string;
-  @ManyToOne(() => SessionEntity, (sessionEntity) => sessionEntity.sessionUser)
+  @ManyToOne(() => SessionEntity, (sessionEntity) => sessionEntity.sessionUser, {
+    onDelete: 'CASCADE',
+  })
   @JoinTable({ name: 'session', joinColumn: { name: 'sessionId' } })
   session: SessionEntity;
 
   @Column()
   courseUserId: string;
-  @ManyToOne(() => CourseUserEntity, (courseUser) => courseUser.sessionUser)
+  @ManyToOne(() => CourseUserEntity, (courseUser) => courseUser.sessionUser, {
+    onDelete: 'CASCADE',
+  })
   @JoinTable({ name: 'course_user', joinColumn: { name: 'courseUserId' } })
   courseUser: CourseUserEntity;
 }

--- a/src/entities/session.entity.ts
+++ b/src/entities/session.entity.ts
@@ -34,10 +34,12 @@ export class SessionEntity extends BaseBloomEntity {
 
   @Column()
   courseId: string;
-  @ManyToOne(() => CourseEntity, (courseEntity) => courseEntity.session)
+  @ManyToOne(() => CourseEntity, (courseEntity) => courseEntity.session, { onDelete: 'CASCADE' })
   @JoinTable({ name: 'course', joinColumn: { name: 'courseId' } })
   course: CourseEntity;
 
-  @OneToMany(() => SessionUserEntity, (sessionUserEntity) => sessionUserEntity.session)
+  @OneToMany(() => SessionUserEntity, (sessionUserEntity) => sessionUserEntity.session, {
+    cascade: true,
+  })
   sessionUser: SessionUserEntity[];
 }

--- a/src/entities/subscription-user.entity.ts
+++ b/src/entities/subscription-user.entity.ts
@@ -13,13 +13,17 @@ export class SubscriptionUserEntity extends BaseBloomEntity {
 
   @Column()
   subscriptionId: string;
-  @ManyToOne(() => SubscriptionEntity, (subscriptionEntity) => subscriptionEntity.subscriptionUser)
+  @ManyToOne(
+    () => SubscriptionEntity,
+    (subscriptionEntity) => subscriptionEntity.subscriptionUser,
+    { onDelete: 'CASCADE' },
+  )
   @JoinTable({ name: 'subscription', joinColumn: { name: 'subscriptionId' } })
   subscription;
 
   @Column()
   userId: string;
-  @ManyToOne(() => UserEntity, (userEntity) => userEntity.subscriptionUser)
+  @ManyToOne(() => UserEntity, (userEntity) => userEntity.subscriptionUser, { onDelete: 'CASCADE' })
   @JoinTable({ name: 'user', joinColumn: { name: 'userId' } })
   user;
 

--- a/src/entities/subscription.entity.ts
+++ b/src/entities/subscription.entity.ts
@@ -10,6 +10,8 @@ export class SubscriptionEntity extends BaseBloomEntity {
   @Column({ unique: true })
   name: string;
 
-  @OneToMany(() => SubscriptionUserEntity, (subscriptionUser) => subscriptionUser.subscription)
+  @OneToMany(() => SubscriptionUserEntity, (subscriptionUser) => subscriptionUser.subscription, {
+    cascade: true,
+  })
   subscriptionUser: SubscriptionUserEntity[];
 }

--- a/src/entities/therapy-session.entity.ts
+++ b/src/entities/therapy-session.entity.ts
@@ -47,7 +47,9 @@ export class TherapySessionEntity extends BaseBloomEntity {
 
   @Column()
   partnerAccessId: string;
-  @ManyToOne(() => PartnerAccessEntity, (partnerAccess) => partnerAccess.therapySession)
+  @ManyToOne(() => PartnerAccessEntity, (partnerAccess) => partnerAccess.therapySession, {
+    onDelete: 'CASCADE',
+  })
   @JoinTable({ name: 'partner_access', joinColumn: { name: 'partnerAccessId' } })
   partnerAccess: PartnerAccessEntity;
 

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -32,19 +32,21 @@ export class UserEntity extends BaseBloomEntity {
   @Column({ type: Boolean, default: true })
   isActive: boolean;
 
-  @OneToMany(() => PartnerAccessEntity, (partnerAccess) => partnerAccess.user)
+  @OneToMany(() => PartnerAccessEntity, (partnerAccess) => partnerAccess.user, { cascade: true })
   partnerAccess: PartnerAccessEntity[];
 
-  @OneToOne(() => PartnerAdminEntity, (partnerAdmin) => partnerAdmin.user)
+  @OneToOne(() => PartnerAdminEntity, (partnerAdmin) => partnerAdmin.user, { cascade: true })
   partnerAdmin: PartnerAdminEntity;
 
-  @OneToMany(() => CourseUserEntity, (courseUser) => courseUser.user)
+  @OneToMany(() => CourseUserEntity, (courseUser) => courseUser.user, { cascade: true })
   courseUser: CourseUserEntity[];
 
-  @OneToMany(() => SubscriptionUserEntity, (subscriptionUser) => subscriptionUser.user)
+  @OneToMany(() => SubscriptionUserEntity, (subscriptionUser) => subscriptionUser.user, {
+    cascade: true,
+  })
   subscriptionUser: SubscriptionUserEntity[];
 
-  @OneToMany(() => TherapySessionEntity, (therapySession) => therapySession.user)
+  @OneToMany(() => TherapySessionEntity, (therapySession) => therapySession.user, { cascade: true })
   therapySession: TherapySessionEntity[];
 
   @Column({ unique: true })

--- a/src/migrations/1697818259254-bloom-backend.ts
+++ b/src/migrations/1697818259254-bloom-backend.ts
@@ -1,0 +1,167 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class bloomBackend1697818259254 implements MigrationInterface {
+  name = 'bloomBackend1697818259254';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "session" DROP CONSTRAINT "FK_2440b236e81d633ff0613ae59d4"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "session_user" DROP CONSTRAINT "FK_3014902f31f2a83ec475d75bec8"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "session_user" DROP CONSTRAINT "FK_5452e53b773936e51ff0e96d064"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "partner_admin" DROP CONSTRAINT "FK_825f3ea183aebdb95a52f1f972c"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "partner_admin" DROP CONSTRAINT "FK_c7ee0521b73218dd1f0b13e23d5"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "therapy_session" DROP CONSTRAINT "FK_95b7041e4d05e914cde6b3753d0"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "partner_access" DROP CONSTRAINT "FK_60f11a3686ca313f1ac25f689f9"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "partner_access" DROP CONSTRAINT "FK_e25f0b4b2c6fbddc8375b02f73e"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscription_user" DROP CONSTRAINT "FK_0feee04ab572b223d511672be81"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscription_user" DROP CONSTRAINT "FK_cdf67f6c499d7a4c7b4d1524850"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "course_user" DROP CONSTRAINT "FK_062e03d78da22a7bd9becbfaaac"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "course_partner" DROP CONSTRAINT "FK_4799c98d625acaae457c7dd23da"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "course_partner" DROP CONSTRAINT "FK_96575d601e92c89fa881d2eb128"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "session" ADD CONSTRAINT "FK_2440b236e81d633ff0613ae59d4" FOREIGN KEY ("courseId") REFERENCES "course"("courseId") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "session_user" ADD CONSTRAINT "FK_5452e53b773936e51ff0e96d064" FOREIGN KEY ("sessionId") REFERENCES "session"("sessionId") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "session_user" ADD CONSTRAINT "FK_3014902f31f2a83ec475d75bec8" FOREIGN KEY ("courseUserId") REFERENCES "course_user"("courseUserId") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "partner_admin" ADD CONSTRAINT "FK_825f3ea183aebdb95a52f1f972c" FOREIGN KEY ("userId") REFERENCES "user"("userId") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "partner_admin" ADD CONSTRAINT "FK_c7ee0521b73218dd1f0b13e23d5" FOREIGN KEY ("partnerId") REFERENCES "partner"("partnerId") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "therapy_session" ADD CONSTRAINT "FK_95b7041e4d05e914cde6b3753d0" FOREIGN KEY ("partnerAccessId") REFERENCES "partner_access"("partnerAccessId") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "partner_access" ADD CONSTRAINT "FK_60f11a3686ca313f1ac25f689f9" FOREIGN KEY ("partnerId") REFERENCES "partner"("partnerId") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "partner_access" ADD CONSTRAINT "FK_e25f0b4b2c6fbddc8375b02f73e" FOREIGN KEY ("partnerAdminId") REFERENCES "partner_admin"("partnerAdminId") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscription_user" ADD CONSTRAINT "FK_cdf67f6c499d7a4c7b4d1524850" FOREIGN KEY ("subscriptionId") REFERENCES "subscription"("subscriptionId") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscription_user" ADD CONSTRAINT "FK_0feee04ab572b223d511672be81" FOREIGN KEY ("userId") REFERENCES "user"("userId") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "course_user" ADD CONSTRAINT "FK_062e03d78da22a7bd9becbfaaac" FOREIGN KEY ("userId") REFERENCES "user"("userId") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "course_partner" ADD CONSTRAINT "FK_96575d601e92c89fa881d2eb128" FOREIGN KEY ("partnerId") REFERENCES "partner"("partnerId") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "course_partner" ADD CONSTRAINT "FK_4799c98d625acaae457c7dd23da" FOREIGN KEY ("courseId") REFERENCES "course"("courseId") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "course_partner" DROP CONSTRAINT "FK_4799c98d625acaae457c7dd23da"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "course_partner" DROP CONSTRAINT "FK_96575d601e92c89fa881d2eb128"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "course_user" DROP CONSTRAINT "FK_062e03d78da22a7bd9becbfaaac"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscription_user" DROP CONSTRAINT "FK_0feee04ab572b223d511672be81"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscription_user" DROP CONSTRAINT "FK_cdf67f6c499d7a4c7b4d1524850"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "partner_access" DROP CONSTRAINT "FK_e25f0b4b2c6fbddc8375b02f73e"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "partner_access" DROP CONSTRAINT "FK_60f11a3686ca313f1ac25f689f9"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "therapy_session" DROP CONSTRAINT "FK_95b7041e4d05e914cde6b3753d0"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "partner_admin" DROP CONSTRAINT "FK_c7ee0521b73218dd1f0b13e23d5"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "partner_admin" DROP CONSTRAINT "FK_825f3ea183aebdb95a52f1f972c"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "session_user" DROP CONSTRAINT "FK_3014902f31f2a83ec475d75bec8"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "session_user" DROP CONSTRAINT "FK_5452e53b773936e51ff0e96d064"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "session" DROP CONSTRAINT "FK_2440b236e81d633ff0613ae59d4"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "course_partner" ADD CONSTRAINT "FK_96575d601e92c89fa881d2eb128" FOREIGN KEY ("partnerId") REFERENCES "partner"("partnerId") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "course_partner" ADD CONSTRAINT "FK_4799c98d625acaae457c7dd23da" FOREIGN KEY ("courseId") REFERENCES "course"("courseId") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "course_user" ADD CONSTRAINT "FK_062e03d78da22a7bd9becbfaaac" FOREIGN KEY ("userId") REFERENCES "user"("userId") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscription_user" ADD CONSTRAINT "FK_cdf67f6c499d7a4c7b4d1524850" FOREIGN KEY ("subscriptionId") REFERENCES "subscription"("subscriptionId") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "subscription_user" ADD CONSTRAINT "FK_0feee04ab572b223d511672be81" FOREIGN KEY ("userId") REFERENCES "user"("userId") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "partner_access" ADD CONSTRAINT "FK_e25f0b4b2c6fbddc8375b02f73e" FOREIGN KEY ("partnerAdminId") REFERENCES "partner_admin"("partnerAdminId") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "partner_access" ADD CONSTRAINT "FK_60f11a3686ca313f1ac25f689f9" FOREIGN KEY ("partnerId") REFERENCES "partner"("partnerId") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "therapy_session" ADD CONSTRAINT "FK_95b7041e4d05e914cde6b3753d0" FOREIGN KEY ("partnerAccessId") REFERENCES "partner_access"("partnerAccessId") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "partner_admin" ADD CONSTRAINT "FK_c7ee0521b73218dd1f0b13e23d5" FOREIGN KEY ("partnerId") REFERENCES "partner"("partnerId") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "partner_admin" ADD CONSTRAINT "FK_825f3ea183aebdb95a52f1f972c" FOREIGN KEY ("userId") REFERENCES "user"("userId") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "session_user" ADD CONSTRAINT "FK_5452e53b773936e51ff0e96d064" FOREIGN KEY ("sessionId") REFERENCES "session"("sessionId") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "session_user" ADD CONSTRAINT "FK_3014902f31f2a83ec475d75bec8" FOREIGN KEY ("courseUserId") REFERENCES "course_user"("courseUserId") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "session" ADD CONSTRAINT "FK_2440b236e81d633ff0613ae59d4" FOREIGN KEY ("courseId") REFERENCES "course"("courseId") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+}


### PR DESCRIPTION
### Issue ticket link / number:
Not applicable

### What changes did you make?
- When partner is deleted, this deletion  cascades and deletes relevant partner_admin, course_partner, partner_access, partner_feature rows. 
- When a user is deleted, this deletion cascades and deletes relevant course_user, partner_admin, subscription_user, therapy_session rows.  
- When a course_user is deleted, this deletion cascades and deletes relevant session_user rows. 
- When a course is deleted, this deletion cascades and deletes relevant course_user, course_partner, session rows. 
- When a feature is deleted, this deletion cascades and deletes relevant partner_feature rows
- When a partner_admin is deleted, this cascades and makes null, relevant access_tokens.
-  When a session is deleted, this cascades and deletes session_user
- When a subscription is deleted, this cascades and deletes subscription user
- 

### Why did you make the changes?
- I wanted to create a reusable db dump from staging with only chayn accounts for volunteers. The issue was all the ondelete cascades were set up incorrectly or not at all and contraints were stopping me from doing this. 

