### PR TITLE
feat: create event logger service and event log webhook

### DIFF
--- a/src/entities/event-log.entity.ts
+++ b/src/entities/event-log.entity.ts
@@ -1,0 +1,23 @@
+import { Column, Entity, JoinTable, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { BaseBloomEntity } from '../entities/base.entity';
+import { UserEntity } from './user.entity';
+
+@Entity({ name: 'event_log' })
+export class EventLogEntity extends BaseBloomEntity {
+  @PrimaryGeneratedColumn('uuid', { name: 'eventLogId' })
+  id: string;
+
+  @Column({ type: 'timestamptz' })
+  date: Date;
+
+  @Column()
+  event: string;
+
+  @Column()
+  userId: string;
+  @ManyToOne(() => UserEntity, (UserEntity) => UserEntity.eventLog, {
+    onDelete: 'CASCADE',
+  })
+  @JoinTable({ name: 'user', joinColumn: { name: 'userId' } })
+  user: UserEntity;
+}

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -3,6 +3,7 @@ import { PartnerAccessEntity } from '../entities/partner-access.entity';
 import { PartnerAdminEntity } from '../entities/partner-admin.entity';
 import { BaseBloomEntity } from './base.entity';
 import { CourseUserEntity } from './course-user.entity';
+import { EventLogEntity } from './event-log.entity';
 import { SubscriptionUserEntity } from './subscription-user.entity';
 import { TherapySessionEntity } from './therapy-session.entity';
 
@@ -48,6 +49,9 @@ export class UserEntity extends BaseBloomEntity {
 
   @OneToMany(() => TherapySessionEntity, (therapySession) => therapySession.user, { cascade: true })
   therapySession: TherapySessionEntity[];
+
+  @OneToMany(() => EventLogEntity, (eventLog) => eventLog.user, { cascade: true })
+  eventLog: EventLogEntity[];
 
   @Column({ unique: true })
   @Generated('uuid')

--- a/src/event-logger/event-logger.interface.ts
+++ b/src/event-logger/event-logger.interface.ts
@@ -1,0 +1,9 @@
+export enum EVENT_NAME {
+  CHAT_MESSAGE_SENT = 'CHAT_MESSAGE_SENT',
+}
+
+export interface ICreateEventLog {
+  date: Date | string;
+  event: EVENT_NAME;
+  userId: string;
+}

--- a/src/event-logger/event-logger.module.ts
+++ b/src/event-logger/event-logger.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { EventLoggerRepository } from './event-logger.repository';
+import { EventLoggerService } from './event-logger.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([EventLoggerRepository])],
+  providers: [EventLoggerService],
+})
+export class SessionModule {}

--- a/src/event-logger/event-logger.repository.ts
+++ b/src/event-logger/event-logger.repository.ts
@@ -1,0 +1,5 @@
+import { EventLogEntity } from 'src/entities/event-log.entity';
+import { EntityRepository, Repository } from 'typeorm';
+
+@EntityRepository(EventLogEntity)
+export class EventLoggerRepository extends Repository<EventLogEntity> {}

--- a/src/event-logger/event-logger.service.ts
+++ b/src/event-logger/event-logger.service.ts
@@ -1,0 +1,33 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EventLogEntity } from 'src/entities/event-log.entity';
+import { ICreateEventLog } from './event-logger.interface';
+import { EventLoggerRepository } from './event-logger.repository';
+
+@Injectable()
+export class EventLoggerService {
+  constructor(
+    @InjectRepository(EventLoggerRepository) private eventLoggerRepository: EventLoggerRepository,
+  ) {}
+
+  async getEventLog(id: string): Promise<EventLogEntity> {
+    return await this.eventLoggerRepository.findOne({ id });
+  }
+
+  async createEventLog({ userId, event, date }: ICreateEventLog) {
+    try {
+      const eventLog = await this.eventLoggerRepository.create({
+        userId,
+        event,
+        date,
+      });
+      const savedEventLog = this.eventLoggerRepository.save(eventLog);
+      return savedEventLog;
+    } catch (err) {
+      throw new HttpException(
+        `createEventLog - failed to create event log ${err}`,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+}

--- a/src/migrations/1698136145516-bloom-backend.ts
+++ b/src/migrations/1698136145516-bloom-backend.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class bloomBackend1698136145516 implements MigrationInterface {
+  name = 'bloomBackend1698136145516';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "event_log" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "eventLogId" uuid NOT NULL DEFAULT uuid_generate_v4(), "date" TIMESTAMP WITH TIME ZONE NOT NULL, "event" character varying NOT NULL, "userId" uuid NOT NULL, CONSTRAINT "PK_0277be94fa0a3e3d3a4e9bed1b2" PRIMARY KEY ("eventLogId"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "event_log" ADD CONSTRAINT "FK_9f8b14e2906ffc001e00e3ae96f" FOREIGN KEY ("userId") REFERENCES "user"("userId") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "event_log" DROP CONSTRAINT "FK_9f8b14e2906ffc001e00e3ae96f"`,
+    );
+    await queryRunner.query(`DROP TABLE "event_log"`);
+  }
+}

--- a/src/partner-admin/partner-admin-auth.guard.spec.ts
+++ b/src/partner-admin/partner-admin-auth.guard.spec.ts
@@ -25,6 +25,7 @@ const userEntity: UserEntity = {
   signUpLanguage: 'en',
   subscriptionUser: [],
   therapySession: [],
+  eventLog: [],
 };
 describe('PartnerAdminAuthGuard', () => {
   let guard: PartnerAdminAuthGuard;
@@ -105,7 +106,10 @@ describe('PartnerAdminAuthGuard', () => {
     );
     jest.spyOn(mockUserRepository, 'createQueryBuilder').mockImplementationOnce(
       createQueryBuilderMock({
-        getOne: jest.fn().mockResolvedValue({ ...userEntity, partnerAdmin: { id: 'partnerAdminId', active: false, partner: {} } }),
+        getOne: jest.fn().mockResolvedValue({
+          ...userEntity,
+          partnerAdmin: { id: 'partnerAdminId', active: false, partner: {} },
+        }),
       }) as never, // TODO resolve this typescript issue
     );
 

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -281,6 +281,7 @@ describe('UserService', () => {
         signUpLanguage,
         contactPermission,
         courseUser,
+        eventLog,
         ...userBase
       } = mockUserEntity;
       jest.spyOn(repo, 'createQueryBuilder').mockImplementationOnce(

--- a/src/webhooks/dto/webhook-create-event-log.dto.ts
+++ b/src/webhooks/dto/webhook-create-event-log.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDate, IsDefined, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { EVENT_NAME } from '../../event-logger/event-logger.interface';
+
+export class WebhookCreateEventLogDto {
+  @IsNotEmpty()
+  @IsString()
+  @IsDefined()
+  @ApiProperty({ type: String })
+  event: EVENT_NAME;
+
+  @IsNotEmpty()
+  @IsDate()
+  @IsDefined()
+  @ApiProperty({ type: Date })
+  date: Date;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty({ type: String })
+  email?: string;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty({ type: String })
+  userId?: string;
+}

--- a/src/webhooks/webhooks.controller.ts
+++ b/src/webhooks/webhooks.controller.ts
@@ -1,6 +1,8 @@
 import { Body, Controller, Logger, Post, UseGuards } from '@nestjs/common';
 import { ApiBody, ApiTags } from '@nestjs/swagger';
+import { EventLogEntity } from 'src/entities/event-log.entity';
 import { ControllerDecorator } from 'src/utils/controller.decorator';
+import { WebhookCreateEventLogDto } from 'src/webhooks/dto/webhook-create-event-log.dto';
 import { ZapierSimplybookBodyDto } from '../partner-access/dtos/zapier-body.dto';
 import { ZapierAuthGuard } from '../partner-access/zapier-auth.guard';
 import { StoryDto } from './dto/story.dto';
@@ -39,6 +41,13 @@ export class WebhooksController {
   @Post('impact-measurement')
   async sendImpactMeasurementEmail(): Promise<string> {
     return this.webhooksService.sendImpactMeasurementEmail();
+  }
+
+  @UseGuards(ZapierAuthGuard)
+  @Post('event-log')
+  @ApiBody({ type: WebhookCreateEventLogDto })
+  async createEventLog(@Body() createEventLogDto): Promise<EventLogEntity> {
+    return this.webhooksService.createEventLog(createEventLogDto);
   }
 
   @Post('storyblok')

--- a/src/webhooks/webhooks.module.ts
+++ b/src/webhooks/webhooks.module.ts
@@ -5,6 +5,8 @@ import { SlackMessageClient } from 'src/api/slack/slack-api';
 import { CoursePartnerRepository } from 'src/course-partner/course-partner.repository';
 import { CoursePartnerService } from 'src/course-partner/course-partner.service';
 import { CourseRepository } from 'src/course/course.repository';
+import { EventLoggerRepository } from 'src/event-logger/event-logger.repository';
+import { EventLoggerService } from 'src/event-logger/event-logger.service';
 import { PartnerAdminRepository } from 'src/partner-admin/partner-admin.repository';
 import { PartnerRepository } from 'src/partner/partner.repository';
 import { PartnerService } from 'src/partner/partner.service';
@@ -28,6 +30,7 @@ import { WebhooksService } from './webhooks.service';
       TherapySessionRepository,
       PartnerAdminRepository,
       EmailCampaignRepository,
+      EventLoggerRepository,
     ]),
   ],
   providers: [
@@ -36,6 +39,7 @@ import { WebhooksService } from './webhooks.service';
     PartnerService,
     MailchimpClient,
     SlackMessageClient,
+    EventLoggerService,
   ],
   controllers: [WebhooksController],
 })

--- a/test/utils/mockData.ts
+++ b/test/utils/mockData.ts
@@ -1,6 +1,7 @@
 import { UserRecord } from 'firebase-admin/lib/auth/user-record';
 import { CourseEntity } from 'src/entities/course.entity';
 import { EmailCampaignEntity } from 'src/entities/email-campaign.entity';
+import { EventLogEntity } from 'src/entities/event-log.entity';
 import { FeatureEntity } from 'src/entities/feature.entity';
 import { PartnerAccessEntity } from 'src/entities/partner-access.entity';
 import { PartnerAdminEntity } from 'src/entities/partner-admin.entity';
@@ -9,6 +10,7 @@ import { PartnerEntity } from 'src/entities/partner.entity';
 import { SessionEntity } from 'src/entities/session.entity';
 import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
 import { UserEntity } from 'src/entities/user.entity';
+import { EVENT_NAME } from 'src/event-logger/event-logger.interface';
 import { IFirebaseUser } from 'src/firebase/firebase-user.interface';
 import { ZapierSimplybookBodyDto } from 'src/partner-access/dtos/zapier-body.dto';
 import {
@@ -138,6 +140,7 @@ export const mockUserEntity: UserEntity = {
   signUpLanguage: 'en',
   subscriptionUser: [],
   therapySession: [],
+  eventLog: [],
 };
 
 export const mockTherapySessionEntity = {
@@ -266,3 +269,9 @@ export const partnerAccessArray = Array.from(
   ],
   (x, index) => ({ ...mockPartnerAccessEntity, accessCode: x.accessCode + index }),
 );
+
+export const mockEventLog: EventLogEntity = {
+  event: EVENT_NAME.CHAT_MESSAGE_SENT,
+  date: new Date(2000, 1, 1),
+  userId: '123',
+} as EventLogEntity;

--- a/test/utils/mockedServices.ts
+++ b/test/utils/mockedServices.ts
@@ -6,6 +6,7 @@ import { CoursePartnerService } from 'src/course-partner/course-partner.service'
 import { CourseRepository } from 'src/course/course.repository';
 import { CourseEntity } from 'src/entities/course.entity';
 import { EmailCampaignEntity } from 'src/entities/email-campaign.entity';
+import { EventLogEntity } from 'src/entities/event-log.entity';
 import { FeatureEntity } from 'src/entities/feature.entity';
 import { PartnerAccessEntity } from 'src/entities/partner-access.entity';
 import { PartnerFeatureEntity } from 'src/entities/partner-feature.entity';
@@ -13,6 +14,7 @@ import { PartnerEntity } from 'src/entities/partner.entity';
 import { SessionEntity } from 'src/entities/session.entity';
 import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
 import { UserEntity } from 'src/entities/user.entity';
+import { EventLoggerService } from 'src/event-logger/event-logger.service';
 import { FeatureRepository } from 'src/feature/feature.repository';
 import { PartnerAccessRepository } from 'src/partner-access/partner-access.repository';
 import { PartnerFeatureRepository } from 'src/partner-feature/partner-feature.repository';
@@ -240,4 +242,10 @@ export const mockFeatureRepositoryMethods: PartialFuncReturn<FeatureRepository> 
     return [{ ...mockFeatureEntity, ...(arg ? { ...arg } : {}) }] as FeatureEntity[];
   },
   save: async (arg) => arg as FeatureEntity,
+};
+
+export const mockEventLoggerServiceMethods: PartialFuncReturn<EventLoggerService> = {
+  createEventLog: async ({ userId, event, date }) => {
+    return { userId, event, date, id: 'eventLogId1ß' } as EventLogEntity;
+  },
 };


### PR DESCRIPTION
### Issue ticket link / number:
N/A - ticket in notion 

### What changes did you make?
- migration to create eventlog service
- eventLog service
- Authenticated webhook endpoint for  zapier to create event logs

### Why did you make the changes?
- we want to track chat usage internally
