### PR TITLE
fix: allow client_id to be optional on simplybook webhook

### DIFF
--- a/src/partner-access/dtos/zapier-body.dto.ts
+++ b/src/partner-access/dtos/zapier-body.dto.ts
@@ -17,10 +17,9 @@ export class ZapierSimplybookBodyDto {
   client_email: string;
 
   @IsString()
-  @IsDefined()
-  @IsNotEmpty()
+  @IsOptional()
   @ApiProperty({ type: String })
-  client_id: string; // This is userId - not to be confused with the simplybook.client_id
+  client_id?: string; // This is userId - not to be confused with the simplybook.client_id
 
   @IsString()
   @IsOptional()

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -144,7 +144,7 @@ describe('UserService', () => {
       expect(user.user.email).toBe('user@email.com');
       expect(user.partnerAdmin).toBeNull();
 
-      const { therapySession, partnerAdmin, partnerAdminId, ...partnerAccessData } =
+      const { therapySession, partnerAdmin, partnerAdminId, userId, ...partnerAccessData } =
         mockPartnerAccessEntity;
       expect(user.partnerAccesses).toEqual([
         { ...partnerAccessData, therapySessions: therapySession },
@@ -203,7 +203,7 @@ describe('UserService', () => {
         ...createUserDto,
         partnerId: mockPartnerEntity.id,
       });
-      const { therapySession, partnerAdmin, partnerAdminId, ...partnerAccessData } =
+      const { therapySession, partnerAdmin, partnerAdminId, userId, ...partnerAccessData } =
         mockPartnerAccessEntity;
       // Note different format for the DTO
       expect(user.partnerAccesses).toEqual([

--- a/src/utils/serialize.spec.ts
+++ b/src/utils/serialize.spec.ts
@@ -1,10 +1,13 @@
-import { mockSimplybookBodyBase } from 'test/utils/mockData';
-import { formatTherapySessionObject } from './serialize';
+import { mockPartnerAccessEntity, mockSimplybookBodyBase } from 'test/utils/mockData';
+import { serializeZapierSimplyBookDtoToTherapySessionEntity } from './serialize';
 
 describe('Serialize', () => {
-  describe('formatTherapySessionObject', () => {
+  describe('serializeZapierSimplyBookDtoToTherapySessionEntity', () => {
     it('should format object correctly when valid object is supplied', () => {
-      const randomString = formatTherapySessionObject(mockSimplybookBodyBase, 'partnerAccessId');
+      const randomString = serializeZapierSimplyBookDtoToTherapySessionEntity(
+        mockSimplybookBodyBase,
+        mockPartnerAccessEntity,
+      );
       expect(randomString).toEqual({
         action: 'UPDATED_BOOKING',
         bookingCode: 'abc',
@@ -13,13 +16,13 @@ describe('Serialize', () => {
         clientTimezone: 'Europe/London',
         completedAt: null,
         endDateTime: new Date('2022-09-12T08:30:00+0000'),
-        partnerAccessId: 'partnerAccessId',
+        partnerAccessId: 'pa1',
         rescheduledFrom: null,
         serviceName: 'bloom therapy',
         serviceProviderEmail: 'therapist@test.com',
-        serviceProviderName: 'therapist@test.com',
+        serviceProviderName: 'Therapist name',
         startDateTime: new Date('2022-09-12T07:30:00+0000'),
-        userId: mockSimplybookBodyBase.client_id,
+        userId: null,
       });
     });
   });

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -147,9 +147,9 @@ export const formatPartnerObject = (partnerObject: PartnerEntity): IPartner => {
   };
 };
 
-export const formatTherapySessionObject = (
+export const serializeZapierSimplyBookDtoToTherapySessionEntity = (
   therapySession: ZapierSimplybookBodyDto,
-  partnerAccessId: string,
+  partnerAccess: PartnerAccessEntity,
 ): Partial<TherapySessionEntity> => {
   return {
     action: therapySession.action,
@@ -157,15 +157,15 @@ export const formatTherapySessionObject = (
     clientEmail: therapySession.client_email,
     clientTimezone: therapySession.client_timezone,
     serviceName: therapySession.service_name,
-    serviceProviderName: therapySession.service_provider_email,
+    serviceProviderName: therapySession.service_provider_name,
     serviceProviderEmail: therapySession.service_provider_email,
     startDateTime: new Date(therapySession.start_date_time),
     endDateTime: new Date(therapySession.end_date_time),
     cancelledAt: null,
     rescheduledFrom: null,
     completedAt: null,
-    partnerAccessId,
-    userId: therapySession.client_id,
+    partnerAccessId: partnerAccess.id,
+    userId: partnerAccess.userId,
   };
 };
 

--- a/src/webhooks/webhooks.controller.spec.ts
+++ b/src/webhooks/webhooks.controller.spec.ts
@@ -1,7 +1,7 @@
 import { createMock } from '@golevelup/ts-jest';
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { mockSimplybookBodyBase } from 'test/utils/mockData';
+import { mockSimplybookBodyBase, mockTherapySessionEntity } from 'test/utils/mockData';
 import { mockWebhooksServiceMethods } from 'test/utils/mockedServices';
 import { WebhooksController } from './webhooks.controller';
 import { WebhooksService } from './webhooks.service';
@@ -23,7 +23,7 @@ describe('AppController', () => {
     it('updatePartnerAccessTherapy should return successful if service returns successful', async () => {
       await expect(
         webhooksController.updatePartnerAccessTherapy(mockSimplybookBodyBase),
-      ).resolves.toBe('Successful');
+      ).resolves.toBe(mockTherapySessionEntity);
     });
     it('updatePartnerAccessTherapy should error  if service returns errors', async () => {
       jest

--- a/src/webhooks/webhooks.controller.ts
+++ b/src/webhooks/webhooks.controller.ts
@@ -1,6 +1,7 @@
 import { Body, Controller, Logger, Post, UseGuards } from '@nestjs/common';
 import { ApiBody, ApiTags } from '@nestjs/swagger';
 import { EventLogEntity } from 'src/entities/event-log.entity';
+import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
 import { ControllerDecorator } from 'src/utils/controller.decorator';
 import { WebhookCreateEventLogDto } from 'src/webhooks/dto/webhook-create-event-log.dto';
 import { ZapierSimplybookBodyDto } from '../partner-access/dtos/zapier-body.dto';
@@ -20,7 +21,7 @@ export class WebhooksController {
   @ApiBody({ type: ZapierSimplybookBodyDto })
   async updatePartnerAccessTherapy(
     @Body() simplybookBodyDto: ZapierSimplybookBodyDto,
-  ): Promise<string> {
+  ): Promise<TherapySessionEntity> {
     const updatedPartnerAccessTherapy = await this.webhooksService.updatePartnerAccessTherapy(
       simplybookBodyDto,
     );
@@ -28,7 +29,7 @@ export class WebhooksController {
       `Updated partner access therapy: ${updatedPartnerAccessTherapy.clientEmail} - ${updatedPartnerAccessTherapy.bookingCode}`,
     );
 
-    return 'Successful';
+    return updatedPartnerAccessTherapy;
   }
 
   @UseGuards(ZapierAuthGuard)

--- a/test/utils/mockData.ts
+++ b/test/utils/mockData.ts
@@ -124,7 +124,7 @@ export const mockIFirebaseUser: IFirebaseUser = {
 };
 
 export const mockUserEntity: UserEntity = {
-  id: '1',
+  id: 'userId1',
   isSuperAdmin: false,
   isActive: true,
   createdAt: new Date(),
@@ -149,20 +149,19 @@ export const mockTherapySessionEntity = {
   partnerAccessId: 'pa1',
   partnerAccess: { id: 'pa1' } as PartnerAccessEntity,
   updatedAt: new Date(),
-  serviceName: 'bloomtherapy',
+  serviceName: 'bloom therapy',
   serviceProviderEmail: 'therapist@test.com',
   serviceProviderName: 'Therapist name',
   bookingCode: '123',
   clientTimezone: 'Europe/London',
   clientEmail: 'client@test.com',
-  name: 'client name',
   startDateTime: new Date('2022-09-12T07:30:00+0100'),
   endDateTime: new Date('2022-09-12T08:30:00+0100'),
   cancelledAt: null,
   rescheduledFrom: null,
   completedAt: null,
   id: 'ts1',
-  userId: 'userId',
+  userId: 'userId1',
   user: { signUpLanguage: 'en' } as UserEntity,
 } as TherapySessionEntity;
 
@@ -176,7 +175,7 @@ export const mockSimplybookBodyBase: ZapierSimplybookBodyDto = {
   booking_code: 'abc',
   service_name: 'bloom therapy',
   service_provider_email: 'therapist@test.com',
-  service_provider_name: 'therapist@test.com',
+  service_provider_name: 'Therapist name',
 };
 
 export const mockPartnerEntity = {
@@ -215,6 +214,7 @@ export const mockPartnerAccessEntity = {
   therapySession: [],
   updatedAt: new Date(),
   active: true,
+  userId: null,
 } as PartnerAccessEntity;
 
 export const mockEmailCampaignEntity: EmailCampaignEntity = {

--- a/test/utils/mockedServices.ts
+++ b/test/utils/mockedServices.ts
@@ -27,6 +27,7 @@ import { UserRepository } from 'src/user/user.repository';
 import { EmailCampaignRepository } from 'src/webhooks/email-campaign/email-campaign.repository';
 import { TherapySessionRepository } from 'src/webhooks/therapy-session.repository';
 import { WebhooksService } from 'src/webhooks/webhooks.service';
+import { DeepPartial } from 'typeorm';
 import {
   mockCourse,
   mockEmailCampaignEntity,
@@ -80,7 +81,12 @@ export const mockTherapySessionRepositoryMethods: PartialFuncReturn<TherapySessi
   findOneOrFail: async (arg) => {
     return { ...mockTherapySessionEntity, ...(arg ? arg : {}) } as TherapySessionEntity;
   },
-  save: async (arg) => arg as TherapySessionEntity,
+  save: async (arg) => {
+    return { ...mockTherapySessionEntity, ...arg } as TherapySessionEntity;
+  },
+  create: (arg: DeepPartial<TherapySessionEntity>) => {
+    return { ...arg, id: 'newTherapySessionId' } as TherapySessionEntity;
+  },
 };
 
 export const mockUserRepositoryMethods: PartialFuncReturn<UserRepository> = {


### PR DESCRIPTION
### Issue ticket link / number:
N/A - ticket in notion

### What changes did you make?

- made client_id an optional parameter on the simplybook webhook
- added tests to safeguard change
- updated other tests as mock data changes had affects on them

### Why did you make the changes?

- errors reported in zapier as users were updating therapy sessions from a link where userId was not available 
