### PR TITLE
GH Actions: issue management base workflow

### DIFF
--- a/.github/workflows/new-assignee-comment.yml
+++ b/.github/workflows/new-assignee-comment.yml
@@ -1,0 +1,23 @@
+# This workflow comments helpful info in issues when they are assigned.
+# For more information, see:
+# https://github.com/actions/first-interaction
+
+name: New Assignee Issue Comment
+on:
+  issues:
+    types:
+      - assigned
+jobs:
+  add-comment:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add comment
+        run: gh issue comment "$NUMBER" --body "$BODY"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          BODY: 'Thank you for your interest in contributing to Chayn! Please carefully read the CONTRIBUTING.md file and the README.md file for guidance. Let us know if you have any questions. Good luck!'
+          

--- a/.github/workflows/stale-issue-management.yml
+++ b/.github/workflows/stale-issue-management.yml
@@ -1,0 +1,35 @@
+# This workflow warns when issues have had no activity for a specified amount of time.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark Stale Issues
+
+on:
+  # Enable manual run from the Actions tab.
+  workflow_dispatch:
+  # Scheduled to run at 12:00 on every 1st of the month.
+  schedule:
+  - cron: '0 12 1 * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      # PR permissions can be added here
+      issues: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        remove-stale-when-updated: false
+        include-only-assigned: true
+        # Disable closing issues
+        days-before-close: -1
+        stale-issue-label: 'stale'
+        # Ignores comments as activity, only looks at date of issue creation.
+        ignore-updates: true
+        # Ignore developer staff and frequent contributors
+        exempt-assignees: 'kyleecodes, swetha-charles, eleanorreem, annarhughes, tarebyte'
+        stale-issue-message: 'As per Chayn policy, after 60 days of inactivity, we will be unassigning this issue to open it back up for contributors. Please comment to be re-assigned. Thank you for your interest in contributing to Chayn!'
+        


### PR DESCRIPTION
### Issue link / number:
https://github.com/chaynHQ/bloom-backend/issues/354

https://github.com/chaynHQ/bloom-backend/issues/328

### What changes did you make?
Two base workflows added - 1 adds comments to stale issues to warn users of reopening task due to inactivity, and another that comments on recently assigned issues with helpful information.

### Why did you make the changes?
Both new workflows provide the base for automated issue management, and are to be improved upon.
