### PR TITLE
Add storyblok auth secret

### DIFF
--- a/.github/workflows/.ci.yml
+++ b/.github/workflows/.ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SIMPLYBOOK_CREDENTIALS: '{"login": "login"}'
+      STORYBLOK_PUBLIC_TOKEN: ${{ secrets.STORYBLOK_PUBLIC_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - name: Get yarn cache directory path

--- a/.github/workflows/.ci.yml
+++ b/.github/workflows/.ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SIMPLYBOOK_CREDENTIALS: '{"login": "login"}'
-      STORYBLOK_PUBLIC_TOKEN: ${{ secrets.STORYBLOK_PUBLIC_TOKEN }}
+      STORYBLOK_WEBHOOK_SECRET: ${{ secrets.STORYBLOK_WEBHOOK_SECRET }}
     steps:
       - uses: actions/checkout@v2
       - name: Get yarn cache directory path

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,10 @@
 {
-  "eslint.packageManager": "yarn",
-  "eslint.alwaysShowStatus": true,
   "editor.formatOnPaste": true,
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true,
-    "source.fixAll": true,
-    "source.fixAll.eslint": true
+    "source.organizeImports": "explicit",
+    "source.fixAll": "explicit",
+    "source.fixAll.eslint": "explicit"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "vetur.format.defaultFormatterOptions": {

--- a/src/webhooks/webhooks.controller.ts
+++ b/src/webhooks/webhooks.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Logger, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Headers, Logger, Post, UseGuards } from '@nestjs/common';
 import { ApiBody, ApiTags } from '@nestjs/swagger';
 import { EventLogEntity } from 'src/entities/event-log.entity';
 import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
@@ -53,7 +53,8 @@ export class WebhooksController {
 
   @Post('storyblok')
   @ApiBody({ type: StoryDto })
-  async updateStory(@Body() storyDto: StoryDto) {
-    return this.webhooksService.updateStory(storyDto);
+  async updateStory(@Body() data: StoryDto, @Headers() headers) {
+    const signature: string | undefined = headers['webhook-signature'];
+    return this.webhooksService.updateStory(data, signature);
   }
 }

--- a/src/webhooks/webhooks.service.spec.ts
+++ b/src/webhooks/webhooks.service.spec.ts
@@ -1,5 +1,6 @@
 import { createMock } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
+import { createHmac } from 'crypto';
 import { format, sub } from 'date-fns';
 import startOfDay from 'date-fns/startOfDay';
 import { MailchimpClient } from 'src/api/mailchimp/mailchip-api';
@@ -48,15 +49,12 @@ import { EmailCampaignRepository } from './email-campaign/email-campaign.reposit
 import { TherapySessionRepository } from './therapy-session.repository';
 import { WebhooksService } from './webhooks.service';
 
-// Difficult to mock classes as well as node modules.
-// This seemed the best approach
-jest.mock('storyblok-js-client', () => {
-  return jest.fn().mockImplementation(() => {
-    return {
-      get: async () => mockSessionStoryblokResult,
-    };
-  });
-});
+const webhookSecret = process.env.STORYBLOK_WEBHOOK_SECRET;
+
+const getWebhookSignature = (body) => {
+  return createHmac('sha1', webhookSecret).update(JSON.stringify(body)).digest('hex');
+};
+
 jest.mock('src/api/simplybook/simplybook-api', () => {
   return {
     getBookingsForDate: async () => [
@@ -181,30 +179,44 @@ describe('WebhooksService', () => {
       });
       expect.assertions(1);
 
-      return expect(
-        service.updateStory({
-          action: STORYBLOK_STORY_STATUS_ENUM.DELETED,
-          story_id: mockSession.storyblokId,
-          text: '',
-        }),
-      ).rejects.toThrowError('STORYBLOK STORY NOT FOUND');
-    });
-
-    it('when action is deleted, story should be set as deleted in database', async () => {
-      const deletedStory = (await service.updateStory({
+      const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.DELETED,
         story_id: mockSession.storyblokId,
         text: '',
-      })) as SessionEntity;
+      };
+
+      return expect(service.updateStory(body, getWebhookSignature(body))).rejects.toThrowError(
+        'STORYBLOK STORY NOT FOUND',
+      );
+    });
+
+    it('when action is deleted, story should be set as deleted in database', async () => {
+      const body = {
+        action: STORYBLOK_STORY_STATUS_ENUM.DELETED,
+        story_id: mockSession.storyblokId,
+        text: '',
+      };
+
+      const deletedStory = (await service.updateStory(
+        body,
+        getWebhookSignature(body),
+      )) as SessionEntity;
+
       expect(deletedStory.status).toBe(STORYBLOK_STORY_STATUS_ENUM.DELETED);
     });
 
     it('when action is unpublished, story should be set as unpublished in database', async () => {
-      const unpublished = (await service.updateStory({
+      const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.UNPUBLISHED,
         story_id: mockSession.storyblokId,
         text: '',
-      })) as SessionEntity;
+      };
+
+      const unpublished = (await service.updateStory(
+        body,
+        getWebhookSignature(body),
+      )) as SessionEntity;
+
       expect(unpublished.status).toBe(STORYBLOK_STORY_STATUS_ENUM.UNPUBLISHED);
     });
 
@@ -245,11 +257,13 @@ describe('WebhooksService', () => {
           return course2;
         });
 
-      const session = (await service.updateStory({
+      const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
         story_id: mockCourse.storyblokId,
         text: '',
-      })) as SessionEntity;
+      };
+
+      const session = (await service.updateStory(body, getWebhookSignature(body))) as SessionEntity;
 
       expect(courseFindOneSpy).toBeCalledWith({
         storyblokUuid: 'anotherCourseUuId',
@@ -286,11 +300,13 @@ describe('WebhooksService', () => {
 
       const courseFindOneSpy = jest.spyOn(mockedCourseRepository, 'findOne');
 
-      const session = (await service.updateStory({
+      const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
         story_id: mockSession.storyblokId,
         text: '',
-      })) as SessionEntity;
+      };
+
+      const session = (await service.updateStory(body, getWebhookSignature(body))) as SessionEntity;
 
       expect(session).toEqual(mockSession);
       expect(courseFindOneSpy).toBeCalledWith({
@@ -342,11 +358,14 @@ describe('WebhooksService', () => {
           },
         };
       });
-      const session = (await service.updateStory({
+
+      const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
         story_id: mockSession.storyblokId,
         text: '',
-      })) as SessionEntity;
+      };
+
+      const session = (await service.updateStory(body, getWebhookSignature(body))) as SessionEntity;
 
       expect(session).toEqual(mockSession);
       expect(sessionSaveRepoSpy).toBeCalledWith({
@@ -373,11 +392,14 @@ describe('WebhooksService', () => {
           get: async () => mockCourseStoryblokResult,
         };
       });
-      const course = (await service.updateStory({
+
+      const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
         story_id: 5678,
         text: '',
-      })) as CourseEntity;
+      };
+
+      const course = (await service.updateStory(body, getWebhookSignature(body))) as CourseEntity;
 
       expect(course).toEqual(mockCourse);
       expect(courseFindOneRepoSpy).toBeCalledWith({

--- a/src/webhooks/webhooks.service.spec.ts
+++ b/src/webhooks/webhooks.service.spec.ts
@@ -55,6 +55,16 @@ const getWebhookSignature = (body) => {
   return createHmac('sha1', webhookSecret).update(JSON.stringify(body)).digest('hex');
 };
 
+// Difficult to mock classes as well as node modules.
+// This seemed the best approach
+jest.mock('storyblok-js-client', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      get: async () => mockSessionStoryblokResult,
+    };
+  });
+});
+
 jest.mock('src/api/simplybook/simplybook-api', () => {
   return {
     getBookingsForDate: async () => [


### PR DESCRIPTION
### What changes did you make?
Adds storyblok secret validation. The storyblok webhook `secret` is set in storyblok, and the storyblok webhook requests now contain a `webhook-signature` header - the signature is a hash/encryption of the body of the request + the webhook `secret`. We now verify the signature by hashing the body with our `STORYBLOK_WEBHOOK_SECRET` env variable

### Why did you make the changes?
As part of stability/security improvements to Bloom - see [ticket](https://www.notion.so/chayn/POST-storyblok-Can-we-put-an-authguard-4d01c246e85a475b8b020c06ddb1c50e?pvs=4)
Follows storyblok [guide](https://www.storyblok.com/docs/guide/in-depth/webhooks#securing-a-webhook) to securing webhooks