### PR TITLE
Add create-release-pr workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,37 @@
+name: Create release PR
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  create-pr-to-main:
+    name: Create release PR to main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Pull Request
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const pullRequestResponse = await github.rest.pulls.list({
+              owner,
+              repo,
+              base: 'main'
+            });
+
+            if (pullRequestResponse.status === 200 && pullRequestResponse.data.length === 0) {
+              const result = await github.rest.pulls.create({
+                title: 'Merge Develop onto Main',
+                owner,
+                repo,
+                head: 'develop',
+                base: 'main',
+                body: [
+                  'This PR was auto-generated - see create-release-pr.yml and ',
+                  '[actions/github-script](https://github.com/actions/github-script).',
+                  'Merging this PR will trigger an automatic deployment to production on Heroku.'
+                ].join('\n')
+              });
+            }


### PR DESCRIPTION
### What changes did you make?
Add workflow to automatically create a `develop` -> `main` PR when new changes are merged to `develop`
This follows the same workflow as in [bloom-frontend](https://github.com/chaynHQ/bloom-frontend/blob/develop/.github/workflows/create-release-pr.yml)

### Why did you make the changes?
To match bloom-frontend workflow, and save time creating manual production/release PRs 
