### PR TITLE
Add New Relic release tracking

### DIFF
--- a/.github/workflows/newrelic-release-tracking.yml
+++ b/.github/workflows/newrelic-release-tracking.yml
@@ -1,0 +1,23 @@
+name: New Relic Release Tracking
+on:
+  release:
+    types: [published]
+    branches: [main]
+
+jobs:
+  newrelic:
+    runs-on: ubuntu-latest
+    name: New Relic Release Tracking
+    steps:
+      # This step builds a var with the release tag value to use later
+      - name: Set Release Version from Tag
+        run: echo "RELEASE_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+      # This step creates a new Change Tracking Marker
+      - name: New Relic Application Deployment Marker
+        uses: newrelic/deployment-marker-action@v2.2.0
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          region: 'EU'
+          guid: ${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}
+          version: '${{ env.RELEASE_VERSION }}'
+          user: '${{ github.actor }}'


### PR DESCRIPTION
### What changes did you make?
Adds release tracking to [New Relic](https://one.newrelic.com/) performance monitoring using the New Relic [github action](https://github.com/marketplace/actions/new-relic-application-deployment-marker)

### Why did you make the changes?
Registers releases in New Relic performance monitoring, making it clearer where changes have affected performance