### PR TITLE
Fix storyblok unpublished and deleted webhook

### DIFF
--- a/src/webhooks/dto/story.dto.ts
+++ b/src/webhooks/dto/story.dto.ts
@@ -22,4 +22,8 @@ export class StoryDto {
   @IsOptional()
   @IsNumber()
   space_id?: number;
+
+  @IsOptional()
+  @IsNumber()
+  full_slug?: string;
 }

--- a/src/webhooks/webhooks.service.spec.ts
+++ b/src/webhooks/webhooks.service.spec.ts
@@ -190,7 +190,7 @@ describe('WebhooksService', () => {
       expect.assertions(1);
 
       const body = {
-        action: STORYBLOK_STORY_STATUS_ENUM.DELETED,
+        action: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
         story_id: mockSession.storyblokId,
         text: '',
       };


### PR DESCRIPTION
### What changes did you make?
Fixes storyblok webhook that updates the database with story changes, i.e. when a Course/Session story is updated (published/unpublished/deleted), the same Course/Session record in our database is updated on the `status` property.

### Why did you make the changes?
On testing recent changes to storyblok auth (#357) I noticed that when unpublishing/deleting a course/session, the webhook does not update the `couse.status = unpublished`