### PR TITLE
Log storyblok webhook

### DIFF
--- a/.github/workflows/newrelic-release-tracking.yml
+++ b/.github/workflows/newrelic-release-tracking.yml
@@ -17,7 +17,7 @@ jobs:
         uses: newrelic/deployment-marker-action@v2.2.0
         with:
           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
-          region: 'EU'
+          region: 'US'
           guid: ${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}
           version: '${{ env.COMMIT_REF }}'
           user: '${{ github.actor }}'

--- a/src/webhooks/webhooks.service.ts
+++ b/src/webhooks/webhooks.service.ts
@@ -462,6 +462,8 @@ export class WebhooksService {
     const action = data.action;
     const story_id = data.story_id;
 
+    this.logger.log('Storyblok action', action);
+
     if (action === STORYBLOK_STORY_STATUS_ENUM.PUBLISHED) {
       let story;
 


### PR DESCRIPTION
### What changes did you make?
Log the result of `action` for debugging

### Why did you make the changes?
Storyblok webhook is returning 404 for `unpublished` and `deleted` actions - see #372 