### PR TITLE
Fix delete cypress users

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -6,6 +6,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { DecodedIdToken } from 'firebase-admin/lib/auth/token-verifier';
+import { Logger } from 'src/logger/logger';
 import { FIREBASE } from '../firebase/firebase-factory';
 import { FirebaseServices } from '../firebase/firebase.types';
 import { UserAuthDto } from './dto/user-auth.dto';
@@ -13,6 +14,7 @@ import { UserAuthDto } from './dto/user-auth.dto';
 @Injectable()
 export class AuthService {
   constructor(@Inject(FIREBASE) private firebase: FirebaseServices) {}
+  private readonly logger = new Logger('AuthService');
 
   public async loginFirebaseUser({ email, password }: UserAuthDto) {
     return await this.firebase.auth.signInWithEmailAndPassword(email, password);
@@ -58,6 +60,47 @@ export class AuthService {
   public async deleteFirebaseUser(firebaseUid: string) {
     try {
       await this.firebase.admin.auth().deleteUser(firebaseUid);
+      return 'ok';
+    } catch (error) {
+      throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
+    }
+  }
+
+  public async deleteCypressFirebaseUsers() {
+    const allUsers = [];
+
+    try {
+      this.firebase.admin
+        .auth()
+        .listUsers(1000)
+        .then((listUsersResult) => {
+          listUsersResult.users.forEach((userRecord) => {
+            if (userRecord.email.includes('cypresstestemail')) {
+              allUsers.push(userRecord.uid);
+            }
+          });
+          this.firebase.admin
+            .auth()
+            .deleteUsers(allUsers)
+            .then((deleteUsersResult) => {
+              if (deleteUsersResult.successCount > 0) {
+                this.logger.log(
+                  `Successfully deleted ${deleteUsersResult.successCount} cypress firebase users`,
+                );
+              }
+
+              if (deleteUsersResult.failureCount > 0) {
+                this.logger.error(
+                  `Failed to delete ${deleteUsersResult.failureCount} cypress firebase users`,
+                );
+              }
+              if (deleteUsersResult.errors.length > 0) {
+                this.logger.error(
+                  `Errors deleting cypress firebase users - ${deleteUsersResult.errors}`,
+                );
+              }
+            });
+        });
       return 'ok';
     } catch (error) {
       throw new HttpException(error.message, HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
### What changes did you make?
Improves delete cypress users functions so the following cases are now handled:
- deletes users with a db record but no firebase record - this previously errored and didn't delete the db record
- deletes firebase users without a db record

### Why did you make the changes?
The delete functions didn't clean up all cases of cypress users, as listed above