### PR TITLE
Add function to delete cypress crisp profiles

### DIFF
--- a/src/api/crisp/crisp-api.ts
+++ b/src/api/crisp/crisp-api.ts
@@ -210,3 +210,25 @@ export const deleteCrispProfile = async (email: string) => {
     throw error;
   }
 };
+
+export const deleteCypressCrispProfiles = async () => {
+  try {
+    const profiles = await apiCall({
+      url: `${baseUrl}/people/profiles/1?search_text=cypresstestemail+`,
+      type: 'get',
+      headers,
+    });
+
+    profiles.data.data.forEach(async (profile) => {
+      await apiCall({
+        url: `${baseUrl}/people/profile/${profile.email}`,
+        type: 'delete',
+        headers,
+      });
+    });
+
+    return 'ok';
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/partner-access/partner-access.service.ts
+++ b/src/partner-access/partner-access.service.ts
@@ -206,7 +206,7 @@ export class PartnerAccessService {
       const partnerAccessRecords = await this.partnerAccessRepository //get partner access instances where user is a cypress user
         .createQueryBuilder('partnerAccess')
         .leftJoinAndSelect('partnerAccess.user', 'user')
-        .where('user.name LIKE :searchTerm', { searchTerm: `%Cypress test user%` })
+        .where('user.name LIKE :searchTerm', { searchTerm: `%Cypress test%` })
         .getMany();
       await Promise.all(
         partnerAccessRecords.map(async (access) => {

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -69,6 +69,13 @@ export class UserController {
     return await this.userService.deleteCypressTestUsers();
   }
 
+  @ApiBearerAuth('access-token')
+  @Delete('/cypress-clean')
+  @UseGuards(SuperAdminAuthGuard)
+  async cleanCypressUsers(): Promise<UserEntity[]> {
+    return await this.userService.deleteCypressTestUsers(true);
+  }
+
   @ApiBearerAuth()
   @Delete(':id')
   @ApiParam({ name: 'id', description: 'User id to delete' })

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -14,6 +14,7 @@ import {
 import {
   addCrispProfile,
   deleteCrispProfile,
+  deleteCypressCrispProfiles,
   updateCrispProfileData,
 } from '../api/crisp/crisp-api';
 import { AuthService } from '../auth/auth.service';
@@ -353,6 +354,7 @@ export class UserService {
 
     return user;
   }
+
   public async deleteCypressTestUsers(): Promise<UserEntity[]> {
     try {
       const queryResult = await this.userRepository
@@ -374,7 +376,10 @@ export class UserService {
       );
 
       // Delete all remaining cypress firebase users (e.g. from failed user creations)
-      this.authService.deleteCypressFirebaseUsers();
+      await this.authService.deleteCypressFirebaseUsers();
+
+      // Delete all remaining crisp accounts
+      await deleteCypressCrispProfiles();
 
       return deletedUsers;
     } catch (error) {


### PR DESCRIPTION
### What changes did you make?
Added `deleteCypressCrispProfiles` function to clean up crisp profiles after cypress tests are run, similar to the existing `deleteCypressTestUsers` and `deleteCypressFirebaseUsers` functions.

Also adds additional endpoint `DELETE /users/cypress-clean` which is similar to `DELETE /users/cypress` but includes a deep clean of rogue firebase and crisp accounts without user db records. This endpoint can be called manually infrequently, but the default (called after each cypress test) is still `/users/cypress` which is faster

### Why did you make the changes?
To clean up our crisp users after they're created during cypress testing, completing the `deleteCypressTestUsers` function