### PR TITLE
Fix workflow triggers

### DIFF
--- a/.github/workflows/.ci.yml
+++ b/.github/workflows/.ci.yml
@@ -2,7 +2,7 @@ name: Bloom Backend CI Pipeline
 
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [develop]
   push:
     branches: [develop]
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,7 +15,7 @@ on:
   push:
     branches: [develop, main]
   pull_request:
-    branches: [develop, main]
+    branches: [develop]
   schedule:
     - cron: '25 5 * * 5'
 

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -2,8 +2,7 @@ name: Create release PR
 
 on:
   push:
-    branches:
-      - develop
+    branches: [develop]
 
 jobs:
   create-pr-to-main:


### PR DESCRIPTION
### What changes did you make?
Removed CI triggers for `pull_request` on `main` branch

### Why did you make the changes?
CI actions were being run twice on develop -> main PRs, due to `push` on `develop` and `pull_request` on `main` being concurrent