### PR TITLE
Fix storyblok full_slug type

### DIFF
--- a/src/webhooks/dto/story.dto.ts
+++ b/src/webhooks/dto/story.dto.ts
@@ -24,6 +24,6 @@ export class StoryDto {
   space_id?: number;
 
   @IsOptional()
-  @IsNumber()
+  @IsString()
   full_slug?: string;
 }


### PR DESCRIPTION
### What changes did you make?
Fixes mismatch of `full_slug?: string` (correct) and `@IsNumber` validation

### Why did you make the changes?
The validation was causing 400 errors on the related storyblok webhook (in `updateStory` function)