### PR TITLE
Refactor simplybook therapy webhook

### DIFF
--- a/src/api/slack/slack-api.ts
+++ b/src/api/slack/slack-api.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { AxiosResponse } from 'axios';
+import { isProduction } from 'src/utils/constants';
 import apiCall from '../apiCalls';
 
 @Injectable()
@@ -9,6 +10,8 @@ export class SlackMessageClient {
   public async sendMessageToTherapySlackChannel(
     text: string,
   ): Promise<AxiosResponse<any, any> | string> {
+    if (!isProduction) return; // only send messages in production environment
+
     try {
       const response = await apiCall({
         url: process.env.SLACK_WEBHOOK_URL,

--- a/src/partner-access/dtos/zapier-body.dto.ts
+++ b/src/partner-access/dtos/zapier-body.dto.ts
@@ -19,7 +19,7 @@ export class ZapierSimplybookBodyDto {
   @IsString()
   @IsOptional()
   @ApiProperty({ type: String })
-  client_id?: string; // This is userId - not to be confused with the simplybook.client_id
+  user_id?: string;
 
   @IsString()
   @IsOptional()

--- a/src/webhooks/therapy-session.interface.ts
+++ b/src/webhooks/therapy-session.interface.ts
@@ -4,7 +4,7 @@ export interface ITherapySession {
   id?: string;
   action?: SIMPLYBOOK_ACTION_ENUM;
   client_email?: string;
-  client_id?: string;
+  user_id?: string;
   client_timezone?: string;
   service_name?: string;
   service_provider_name?: string;

--- a/src/webhooks/webhooks.controller.ts
+++ b/src/webhooks/webhooks.controller.ts
@@ -22,14 +22,7 @@ export class WebhooksController {
   async updatePartnerAccessTherapy(
     @Body() simplybookBodyDto: ZapierSimplybookBodyDto,
   ): Promise<TherapySessionEntity> {
-    const updatedPartnerAccessTherapy = await this.webhooksService.updatePartnerAccessTherapy(
-      simplybookBodyDto,
-    );
-    this.logger.log(
-      `Updated partner access therapy: ${updatedPartnerAccessTherapy.clientEmail} - ${updatedPartnerAccessTherapy.bookingCode}`,
-    );
-
-    return updatedPartnerAccessTherapy;
+    return this.webhooksService.updatePartnerAccessTherapy(simplybookBodyDto);
   }
 
   @UseGuards(ZapierAuthGuard)

--- a/src/webhooks/webhooks.service.spec.ts
+++ b/src/webhooks/webhooks.service.spec.ts
@@ -555,6 +555,21 @@ describe('WebhooksService', () => {
       ).resolves.toHaveProperty('action', SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING);
     });
 
+    it('should add therapyRemaining to original partner access when action is cancel', async () => {
+      const partnerAccessSaveSpy = jest.spyOn(mockedPartnerAccessRepository, 'save');
+      await expect(
+        service.updatePartnerAccessTherapy({
+          ...mockSimplybookBodyBase,
+          ...{ action: SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING },
+        }),
+      ).resolves.toHaveProperty('action', SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING);
+      expect(partnerAccessSaveSpy).toBeCalledWith({
+        ...mockPartnerAccessEntity,
+        therapySessionsRemaining: mockPartnerAccessEntity.therapySessionsRemaining + 1,
+        therapySessionsRedeemed: mockPartnerAccessEntity.therapySessionsRedeemed - 1,
+      });
+    });
+
     it('should set a booking as cancelled when action is cancel and there are no therapy sessions remaining TODO', async () => {
       // mock that there is no therapy sessions remaining on partner access
       const partnerAccessFindSpy = jest

--- a/src/webhooks/webhooks.service.ts
+++ b/src/webhooks/webhooks.service.ts
@@ -288,8 +288,8 @@ export class WebhooksService {
           id: existingTherapySession.partnerAccessId,
         });
 
-        partnerAccess.therapySessionsRemaining + 1;
-        partnerAccess.therapySessionsRedeemed - 1;
+        partnerAccess.therapySessionsRemaining += 1;
+        partnerAccess.therapySessionsRedeemed -= 1;
 
         await this.partnerAccessRepository.save(partnerAccess);
 

--- a/src/webhooks/webhooks.service.ts
+++ b/src/webhooks/webhooks.service.ts
@@ -10,6 +10,7 @@ import { EventLogEntity } from 'src/entities/event-log.entity';
 import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
 import { EventLoggerService } from 'src/event-logger/event-logger.service';
 import { ZapierSimplybookBodyDto } from 'src/partner-access/dtos/zapier-body.dto';
+import { IUser } from 'src/user/user.interface';
 import { serializeZapierSimplyBookDtoToTherapySessionEntity } from 'src/utils/serialize';
 import { getYesterdaysDate } from 'src/utils/utils';
 import { WebhookCreateEventLogDto } from 'src/webhooks/dto/webhook-create-event-log.dto';
@@ -18,7 +19,6 @@ import { Between } from 'typeorm';
 import { getCrispPeopleData, updateCrispProfileData } from '../api/crisp/crisp-api';
 import { CoursePartnerService } from '../course-partner/course-partner.service';
 import { CourseRepository } from '../course/course.repository';
-import { PartnerAccessEntity } from '../entities/partner-access.entity';
 import { PartnerAccessRepository } from '../partner-access/partner-access.repository';
 import { SessionRepository } from '../session/session.repository';
 import { UserRepository } from '../user/user.repository';
@@ -26,6 +26,7 @@ import {
   CAMPAIGN_TYPE,
   SIMPLYBOOK_ACTION_ENUM,
   STORYBLOK_STORY_STATUS_ENUM,
+  isProduction,
   storyblokToken,
 } from '../utils/constants';
 import { StoryDto } from './dto/story.dto';
@@ -235,228 +236,304 @@ export class WebhooksService {
     }
 
     updateCrispProfileData(partnerAccessUpdateCrisp, email);
-
-    return 'ok';
-  }
-  private async createTherapySession(
-    simplyBookDto: ZapierSimplybookBodyDto,
-    partnerAccess: PartnerAccessEntity,
-  ) {
-    const therapySession = serializeZapierSimplyBookDtoToTherapySessionEntity(
-      simplyBookDto,
-      partnerAccess,
-    );
-    return await this.therapySessionRepository.save(therapySession);
-  }
-
-  private async updateTherapySession(
-    action,
-    simplyBookDto: ZapierSimplybookBodyDto,
-    therapySession: TherapySessionEntity,
-  ): Promise<TherapySessionEntity> {
-    const updatedTherapySession = {
-      ...therapySession,
-      action,
-      ...(action === SIMPLYBOOK_ACTION_ENUM.UPDATED_BOOKING
-        ? {
-            rescheduledFrom: therapySession.startDateTime,
-            startDateTime: new Date(simplyBookDto.start_date_time),
-            endDateTime: new Date(simplyBookDto.end_date_time),
-          }
-        : {}),
-      ...(action === SIMPLYBOOK_ACTION_ENUM.COMPLETED_BOOKING ? { completedAt: new Date() } : {}),
-      ...(action === SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING ? { cancelledAt: new Date() } : {}),
-    };
-
-    return await this.therapySessionRepository.save(updatedTherapySession);
   }
 
   async updatePartnerAccessTherapy(
     simplyBookDto: ZapierSimplybookBodyDto,
   ): Promise<TherapySessionEntity> {
-    const { action, booking_code, client_id } = simplyBookDto;
-
-    // this ensures that the client email can be matched against the db which contains lower case emails
-    const client_email = simplyBookDto.client_email.toLowerCase();
+    const { action, booking_code, user_id, client_email } = simplyBookDto;
 
     this.logger.log(
-      `UpdatePartnerAccessService method initiated for ${action} - ${client_email} - ${booking_code} - userId ${simplyBookDto.client_id}`,
+      `Update therapy session webhook function STARTED for ${action} - ${client_email} - ${booking_code} - userId ${user_id}`,
     );
 
-    const inferIdFromPreviousTherapySessionOrUser = async () => {
-      try {
-        const previousTherapySession = await this.therapySessionRepository.findOne({
-          clientEmail: client_email,
-        });
-
-        // If there are no previous therapy sessions, try matching email with user
-        if (!previousTherapySession) {
-          const user = await this.userRepository.findOne({ email: client_email });
-
-          return user?.id;
-        }
-
-        return previousTherapySession?.userId;
-      } catch (err) {
-        throw new HttpException(
-          `inferIdFromPreviousTherapySessionOrUser - error finding userId from therapyRepository or userRepository ${err}`,
-          HttpStatus.INTERNAL_SERVER_ERROR,
-        );
-      }
-    };
-
-    // Retrieve therapy session
-    const therapySession: TherapySessionEntity | undefined =
-      action === SIMPLYBOOK_ACTION_ENUM.NEW_BOOKING
-        ? undefined
-        : await this.therapySessionRepository.findOne({
-            bookingCode: booking_code,
-            clientEmail: client_email,
-          });
-
-    const userId: string | undefined =
-      client_id || therapySession?.userId || (await inferIdFromPreviousTherapySessionOrUser());
-
-    // ensure user exists and throw error if not
-    const userDetails = await this.userRepository.findOne({ id: userId });
-    if (!userDetails) {
-      await this.slackMessageClient.sendMessageToTherapySlackChannel(
-        `Unknown user made a therapy booking - ${client_email}, id: ${userId} 🚨`,
-      );
-      this.logger.error(
-        `UpdatePartnerAccessTherapy, Unable to find user with email ${client_email}, id ${userId}`,
-      );
-      throw new HttpException(
-        `UpdatePartnerAccessTherapy, Unable to find user with email ${client_email}, id ${userId}`,
-        HttpStatus.BAD_REQUEST,
-      );
-    }
-
-    // Handle partner access changes
-    const usersPartnerAccesses = await this.partnerAccessRepository.find({
-      userId: userDetails.id,
-      active: true,
+    // Retrieve existing therapy session record for this booking
+    const existingTherapySession = await this.therapySessionRepository.findOne({
+      where: `"clientEmail" ILIKE '${client_email}' AND "bookingCode" LIKE '${booking_code}'`,
     });
 
-    if (usersPartnerAccesses.length === 0) {
-      this.logger.error('Unable to find partner access');
-      throw new HttpException('Unable to find partner access', HttpStatus.BAD_REQUEST);
-    }
-    // Filter all partner accesses and get the ones that have therapy available
-    const therapyPartnerAccesses: PartnerAccessEntity[] = usersPartnerAccesses
-      .filter((pa) => {
-        return pa.featureTherapy === true;
-      })
-      .sort((a: any, b: any) => {
-        return a.createdAt - b.createdAt;
-      });
-
-    // throw error if none have therapy enabled
-    if (therapyPartnerAccesses.length === 0) {
-      this.logger.error('User  has no partner access with therapy available');
-
-      throw new HttpException(
-        'User has no partner access with therapy available',
-        HttpStatus.FORBIDDEN,
-      );
+    if (action !== SIMPLYBOOK_ACTION_ENUM.NEW_BOOKING && !existingTherapySession) {
+      const error = `UpdatePartnerAccessTherapy - existing therapy session not found for user ${client_email} booking code ${booking_code}`;
+      this.logger.error(error);
+      throw new HttpException(error, HttpStatus.BAD_REQUEST);
     }
 
+    if (action === SIMPLYBOOK_ACTION_ENUM.NEW_BOOKING && existingTherapySession && isProduction) {
+      const error = `UpdatePartnerAccessTherapy - therapy session already exists for ${client_email} booking code ${booking_code}, preventing duplicate NEW_BOOKING action`;
+      this.logger.error(error);
+      throw new HttpException(error, HttpStatus.FOUND);
+    }
+
+    const userId = user_id || existingTherapySession?.userId;
+    const user = await this.getSimplyBookTherapyUser(userId, client_email);
+
+    // Creating a new therapy session
     if (action === SIMPLYBOOK_ACTION_ENUM.NEW_BOOKING) {
-      return await this.newPartnerAccessTherapy(therapyPartnerAccesses, simplyBookDto);
+      const therapySession = await this.newPartnerAccessTherapy(user, simplyBookDto);
+      this.logger.log(
+        `Update therapy session webhook function COMPLETED for ${action} - ${user.email} - ${booking_code} - userId ${user_id}`,
+      );
+      return therapySession;
     }
 
-    if (!therapySession) {
-      throw new HttpException('Therapy session not found', HttpStatus.FORBIDDEN);
-    }
+    // Updating an existing therapy session
+    existingTherapySession.action = action;
 
-    this.updateCrispProfileTherapyData(action, client_email);
+    this.updateCrispProfileTherapyData(action, user.email);
 
-    // if it is a cancelled booking, add a therapy session
+    // If the booking is cancelled, increment the therapy sessions remaining on related partner access
     if (action === SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING) {
-      // Any partner access therapy session will do
-      const therapyPartnerAccess = therapyPartnerAccesses[0];
-      const partnerAccessUpdateDetails = {
-        therapySessionsRemaining: therapyPartnerAccess.therapySessionsRemaining + 1,
-        therapySessionsRedeemed: therapyPartnerAccess.therapySessionsRedeemed - 1,
-      };
       try {
-        await this.partnerAccessRepository.save(
-          Object.assign(therapyPartnerAccess, { ...partnerAccessUpdateDetails }),
-        );
+        const partnerAccess = await this.partnerAccessRepository.findOne({
+          id: existingTherapySession.partnerAccessId,
+        });
+
+        partnerAccess.therapySessionsRemaining + 1;
+        partnerAccess.therapySessionsRedeemed - 1;
+
+        await this.partnerAccessRepository.save(partnerAccess);
+
+        existingTherapySession.cancelledAt = new Date();
       } catch (err) {
-        throw err;
+        const error = `UpdatePartnerAccessTherapy - error updating partner access for ${action} - email ${user.email} userId ${user.id} - ${err}`;
+        this.logger.error(error);
+        throw new HttpException(error, HttpStatus.INTERNAL_SERVER_ERROR);
       }
+    }
+
+    if (action === SIMPLYBOOK_ACTION_ENUM.COMPLETED_BOOKING) {
+      existingTherapySession.completedAt = new Date();
+    }
+
+    if (action === SIMPLYBOOK_ACTION_ENUM.UPDATED_BOOKING) {
+      existingTherapySession.rescheduledFrom = existingTherapySession.startDateTime;
+      existingTherapySession.startDateTime = new Date(simplyBookDto.start_date_time);
+      existingTherapySession.endDateTime = new Date(simplyBookDto.end_date_time);
     }
 
     try {
-      const updatedTherapySession = await this.updateTherapySession(
-        action,
-        simplyBookDto,
-        therapySession,
+      const therapySession = await this.therapySessionRepository.save(existingTherapySession);
+      this.logger.log(
+        `Update therapy session webhook function COMPLETED for ${action} - ${user.email} - ${booking_code} - userId ${user_id}`,
       );
-
-      return updatedTherapySession;
-    } catch (error) {
+      return therapySession;
+    } catch (err) {
+      const error = `UpdatePartnerAccessTherapy - error updating therapy session for ${action} - email ${user.email} userId ${user.id} - ${err}`;
       this.logger.error(error);
-      throw error;
+      throw new HttpException(error, HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
-  private async newPartnerAccessTherapy(
-    partnerAccesses: PartnerAccessEntity[],
-    simplyBookDto: ZapierSimplybookBodyDto,
-  ) {
-    const therapyPartnerAccess = partnerAccesses.filter(
-      (tpa) => tpa.therapySessionsRemaining > 0,
-    )[0];
-    // if it is new booking, therapy sessions must be available
-    if (typeof therapyPartnerAccess === 'undefined') {
-      await this.slackMessageClient.sendMessageToTherapySlackChannel(
-        `User booked therapy with no therapy sessions remaining, please email user ${simplyBookDto.client_email} to confirm the booking has not been made`,
-      );
-      throw new HttpException('No therapy sessions remaining', HttpStatus.FORBIDDEN);
+  private async getSimplyBookTherapyUser(userId: string, client_email: string): Promise<IUser> {
+    if (!userId) {
+      // No userId sent in the webhook - likely due to user clicking simplybook link from email instead of in-app widget
+      // Try to find a user associated to this email
+      try {
+        // Check for previous therapy sessions associated to the email
+        const previousTherapySession = await this.therapySessionRepository.findOne({
+          where: `"clientEmail" ILIKE '${client_email}'`,
+        });
+
+        if (previousTherapySession?.userId) {
+          userId = previousTherapySession.userId;
+        } else {
+          // No previous therapy sessions, try matching email with user
+          const user = await this.userRepository.findOne({
+            where: `"email" ILIKE '${client_email}'`,
+          });
+          if (user?.id) {
+            userId = user.id;
+          }
+        }
+      } catch (err) {
+        const error = `UpdatePartnerAccessTherapy - error finding user in therapyRepository or userRepository with email ${client_email} - ${err}`;
+        this.logger.error(error);
+        throw new HttpException(error, HttpStatus.INTERNAL_SERVER_ERROR);
+      }
+      if (!userId) {
+        // All searches tried and failed, throw 404/400 error
+        const error = `UpdatePartnerAccessTherapy - user not found for email ${client_email} and no userId provided or found`;
+        this.logger.error(error);
+        throw new HttpException(error, HttpStatus.BAD_REQUEST);
+      }
     }
 
-    this.updateCrispProfileTherapyData(
-      SIMPLYBOOK_ACTION_ENUM.NEW_BOOKING,
-      simplyBookDto.client_email,
-    );
+    try {
+      // userId available, find and return user record
+      const user = await this.userRepository.findOne({ id: userId });
+      if (user) return user;
 
-    // if it is a new booking, deduct a therapy session
-    const partnerAccessUpdateDetails = {
-      therapySessionsRemaining: therapyPartnerAccess.therapySessionsRemaining - 1,
-      therapySessionsRedeemed: therapyPartnerAccess.therapySessionsRedeemed + 1,
-    };
+      // No user record found for userId, throw error
+      await this.slackMessageClient.sendMessageToTherapySlackChannel(
+        `Unknown user made a therapy booking with email ${client_email}, userID ${userId} 🚨`,
+      );
+      const error = `UpdatePartnerAccessTherapy - user not found for userID ${userId}, with origin client_email ${client_email}`;
+      this.logger.error(error);
+      throw new HttpException(error, HttpStatus.BAD_REQUEST);
+    } catch (err) {
+      const error = `UpdatePartnerAccessTherapy - error finding user with userID ${userId} and origin client_email ${client_email}`;
+      this.logger.error(error);
+      throw new HttpException(error, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  private async newPartnerAccessTherapy(user: IUser, simplyBookDto: ZapierSimplybookBodyDto) {
+    const partnerAccesses = await this.partnerAccessRepository.find({
+      userId: user.id,
+      active: true,
+      featureTherapy: true,
+    });
+
+    if (!partnerAccesses.length) {
+      await this.slackMessageClient.sendMessageToTherapySlackChannel(
+        `User booked therapy with no partner therapy access, please email user ${user.email} to confirm the booking has not been made and fix the account access`,
+      );
+      const error = `newPartnerAccessTherapy - no partner therapy access - email ${user.email} userId ${user.id}`;
+      this.logger.error(error);
+      throw new HttpException(error, HttpStatus.FORBIDDEN);
+    }
+
+    const partnerAccess = partnerAccesses
+      .filter((tpa) => tpa.therapySessionsRemaining > 0)
+      .sort((a: any, b: any) => {
+        return a.createdAt - b.createdAt;
+      })[0];
+
+    if (!partnerAccess) {
+      await this.slackMessageClient.sendMessageToTherapySlackChannel(
+        `User booked therapy with no therapy sessions remaining, please email user ${user.email} to confirm the booking has not been made`,
+      );
+      const error = `newPartnerAccessTherapy - user has partner therapy access but has 0 therapy sessions remaining - email ${user.email} userId ${user.id}`;
+      this.logger.error(error);
+      throw new HttpException(error, HttpStatus.FORBIDDEN);
+    }
+
+    this.updateCrispProfileTherapyData(SIMPLYBOOK_ACTION_ENUM.NEW_BOOKING, user.email);
+
+    partnerAccess.therapySessionsRemaining -= 1;
+    partnerAccess.therapySessionsRedeemed += 1;
 
     try {
-      const therapySession = await this.createTherapySession(simplyBookDto, therapyPartnerAccess);
-
-      await this.partnerAccessRepository.save(
-        Object.assign(therapyPartnerAccess, { ...partnerAccessUpdateDetails }),
+      const serializedTherapySession = serializeZapierSimplyBookDtoToTherapySessionEntity(
+        simplyBookDto,
+        partnerAccess,
       );
+      await this.partnerAccessRepository.save(partnerAccess);
+      return await this.therapySessionRepository.save(serializedTherapySession);
+    } catch (err) {
+      const error = `newPartnerAccessTherapy - error saving new therapy session and partner access - email ${user.email} userId ${user.id} - ${err}`;
+      this.logger.error(error);
+      throw new HttpException(error, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
 
-      return therapySession;
-    } catch (error) {
-      throw error;
+  private async createNewStory(story_id: number, action: STORYBLOK_STORY_STATUS_ENUM) {
+    let story;
+
+    const Storyblok = new StoryblokClient({
+      accessToken: storyblokToken,
+      cache: {
+        clear: 'auto',
+        type: 'memory',
+      },
+    });
+
+    try {
+      const response = await Storyblok.get(`cdn/stories/${story_id}`);
+      if (response?.data?.story) {
+        story = response.data.story;
+      }
+    } catch (err) {
+      const error = `Storyblok webhook failed - error getting story from storyblok - ${err}`;
+      this.logger.error(error);
+      throw new HttpException(error, HttpStatus.NOT_FOUND);
+    }
+
+    const storyData = {
+      name: story.name,
+      slug: story.full_slug,
+      status: action,
+      storyblokId: story_id,
+      storyblokUuid: story.uuid,
+    };
+    try {
+      if (story.content?.component === 'Course') {
+        let course = await this.courseRepository.findOne({
+          storyblokId: story_id,
+        });
+
+        if (!!course) {
+          course.status = action;
+          course.slug = story.full_slug;
+        } else {
+          course = this.courseRepository.create(storyData);
+        }
+        course.name = story.content?.name;
+        course = await this.courseRepository.save(course);
+
+        await this.coursePartnerService.updateCoursePartners(
+          story.content?.included_for_partners,
+          course.id,
+        );
+
+        this.logger.log(`Storyblok course ${action} success - ${course.name}`);
+        return course;
+      } else if (
+        story.content?.component === 'Session' ||
+        story.content?.component === 'session_iba'
+      ) {
+        const course = await this.courseRepository.findOne({
+          storyblokUuid: story.content.course,
+        });
+
+        if (!course.id) {
+          const error = `Storyblok webhook failed - course not found for session story`;
+          this.logger.error(error);
+          throw new HttpException(error, HttpStatus.NOT_FOUND);
+        }
+
+        let session = await this.sessionRepository.findOne({
+          storyblokId: story_id,
+        });
+
+        const newSession = !!session
+          ? {
+              ...session,
+              status: action,
+              slug: story.full_slug,
+              name: story.name,
+              course: course,
+              courseId: course.id,
+            }
+          : this.sessionRepository.create({ ...storyData, ...{ courseId: course.id } });
+
+        session = await this.sessionRepository.save(newSession);
+        this.logger.log(`Storyblok session ${action} success - ${session.name}`);
+        return session;
+      }
+      return undefined; // New story wasn't a course or session story, ignore
+    } catch (err) {
+      const error = `Storyblok webhook failed - error creating new ${story.content?.component} record - ${err}`;
+      this.logger.error(error);
+      throw new HttpException(error, HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
   async updateStory(data: StoryDto, signature: string | undefined) {
     // Verify storyblok signature uses storyblok webhook secret - see https://www.storyblok.com/docs/guide/in-depth/webhooks#securing-a-webhook
     if (!signature) {
-      throw new HttpException(
-        'Storyblok webhook failed: no signature provided',
-        HttpStatus.UNAUTHORIZED,
-      );
+      const error = `Storyblok webhook error - no signature provided`;
+      this.logger.error(error);
+      throw new HttpException(error, HttpStatus.UNAUTHORIZED);
     }
+
     const webhookSecret = process.env.STORYBLOK_WEBHOOK_SECRET;
     const bodyHmac = createHmac('sha1', webhookSecret).update(JSON.stringify(data)).digest('hex');
 
     if (bodyHmac !== signature) {
-      throw new HttpException(
-        'Storyblok webhook failed: signature mismatch',
-        HttpStatus.UNAUTHORIZED,
-      );
+      const error = `Storyblok webhook error - signature mismatch`;
+      this.logger.error(error);
+      throw new HttpException(error, HttpStatus.UNAUTHORIZED);
     }
 
     const action = data.action;
@@ -465,136 +542,47 @@ export class WebhooksService {
     this.logger.log(`Storyblok story ${action} request - ${story_id}`);
 
     if (action === STORYBLOK_STORY_STATUS_ENUM.PUBLISHED) {
-      let story;
+      return this.createNewStory(story_id, action);
+    }
 
-      const Storyblok = new StoryblokClient({
-        accessToken: storyblokToken,
-        cache: {
-          clear: 'auto',
-          type: 'memory',
-        },
-      });
+    // Story was unpublished or deleted so cant be fetched from storyblok to get story type (Course or Session)
+    // Try to find course with matching story_id first
+    let course = await this.courseRepository.findOne({
+      storyblokId: story_id,
+    });
 
-      try {
-        const {
-          data: { story: storyblokData },
-        } = await Storyblok.get(`cdn/stories/${story_id}`);
-        story = storyblokData;
-      } catch (error) {
-        throw new HttpException(error, HttpStatus.NOT_FOUND);
-      }
-
-      if (!story) {
-        throw new HttpException('STORY NOT FOUND', HttpStatus.NOT_FOUND);
-      }
-
-      const storyData = {
-        name: story.name,
-        slug: story.full_slug,
-        status: action,
-        storyblokId: story_id,
-        storyblokUuid: story.uuid,
-      };
-      try {
-        if (story.content?.component === 'Course') {
-          let course = await this.courseRepository.findOne({
-            storyblokId: story_id,
-          });
-
-          if (!!course) {
-            course.status = action;
-            course.slug = story.full_slug;
-          } else {
-            course = this.courseRepository.create(storyData);
-          }
-          course.name = story.content?.name;
-          course = await this.courseRepository.save(course);
-
-          await this.coursePartnerService.updateCoursePartners(
-            story.content?.included_for_partners,
-            course.id,
-          );
-
-          this.logger.log(`Storyblok course ${action} success - ${course.name}`);
-          return course;
-        } else if (
-          story.content?.component === 'Session' ||
-          story.content?.component === 'session_iba'
-        ) {
-          const course = await this.courseRepository.findOne({
-            storyblokUuid: story.content.course,
-          });
-
-          if (!course.id) {
-            throw new HttpException('COURSE NOT FOUND', HttpStatus.NOT_FOUND);
-          }
-
-          let session = await this.sessionRepository.findOne({
-            storyblokId: story_id,
-          });
-
-          const newSession = !!session
-            ? {
-                ...session,
-                status: action,
-                slug: story.full_slug,
-                name: story.name,
-                course: course,
-                courseId: course.id,
-              }
-            : this.sessionRepository.create({ ...storyData, ...{ courseId: course.id } });
-
-          session = await this.sessionRepository.save(newSession);
-          this.logger.log(`Storyblok session ${action} success - ${session.name}`);
-          return session;
-        }
-      } catch (error) {
-        throw error;
-      }
-    } else if (
-      action === STORYBLOK_STORY_STATUS_ENUM.UNPUBLISHED ||
-      action === STORYBLOK_STORY_STATUS_ENUM.DELETED
-    ) {
-      // Story was unpublished or deleted so cant be fetched to check story type (Course or Session)
-      // Try to find course with matching story_id first
-      let course = await this.courseRepository.findOne({
+    if (!!course) {
+      course.status = action;
+      course = await this.courseRepository.save(course);
+      this.logger.log(`Storyblok course ${action} success - ${course.name}`);
+      return course;
+    } else if (!course) {
+      // No course found, try finding session instead
+      let session = await this.sessionRepository.findOne({
         storyblokId: story_id,
       });
 
-      if (!!course) {
-        course.status = action;
-        course = await this.courseRepository.save(course);
-        this.logger.log(`Storyblok course ${action} success - ${course.name}`);
-        return course;
-      } else if (!course) {
-        // No course found, try finding session instead
-        let session = await this.sessionRepository.findOne({
-          storyblokId: story_id,
-        });
-
-        if (!!session) {
-          session.status = action;
-          session = await this.sessionRepository.save(session);
-          this.logger.log(`Storyblok session ${action} success - ${session.name}`);
-          return session;
-        }
+      if (!!session) {
+        session.status = action;
+        session = await this.sessionRepository.save(session);
+        this.logger.log(`Storyblok session ${action} success - ${session.name}`);
+        return session;
       }
     }
   }
 
   async createEventLog(createEventDto: WebhookCreateEventLogDto): Promise<EventLogEntity> {
     if (!createEventDto.email && !createEventDto.userId) {
-      throw new HttpException(
-        'webhooks.createEventLog - Neither User email or userId was provided',
-        HttpStatus.BAD_REQUEST,
-      );
+      const error = `createEventLog webhook failed - neither user email or userId was provided`;
+      this.logger.error(error);
+      throw new HttpException(error, HttpStatus.BAD_REQUEST);
     }
 
     try {
-      // Only fetch user object if strictly necessary
+      // Only fetch user object if the userId is not provided
       const user = createEventDto.userId
         ? undefined
-        : await this.userRepository.findOne({ email: createEventDto.email });
+        : await this.userRepository.findOne({ where: `"email" ILIKE '${createEventDto.email}'` });
 
       if (user || createEventDto.userId) {
         const event = await this.eventLoggerService.createEventLog({
@@ -604,10 +592,9 @@ export class WebhooksService {
         });
         return event;
       } else {
-        throw new HttpException(
-          `webhooksService.createEventLog error, no user attached to email ${createEventDto.email}`,
-          HttpStatus.NOT_FOUND,
-        );
+        const error = `createEventLog webhook failed - no user attached to email ${createEventDto.email}`;
+        this.logger.error(error);
+        throw new HttpException(error, HttpStatus.NOT_FOUND);
       }
     } catch (err) {
       throw err;

--- a/test/utils/mockData.ts
+++ b/test/utils/mockData.ts
@@ -170,7 +170,7 @@ export const mockSimplybookBodyBase: ZapierSimplybookBodyDto = {
   start_date_time: '2022-09-12T07:30:00+0000',
   end_date_time: '2022-09-12T08:30:00+0000',
   client_email: 'testuser@test.com',
-  client_id: '115e272a-5fc3-4991-8ea9-12dacad25bae',
+  user_id: '115e272a-5fc3-4991-8ea9-12dacad25bae',
   client_timezone: 'Europe/London',
   booking_code: 'abc',
   service_name: 'bloom therapy',


### PR DESCRIPTION
### What changes did you make?
Refactored simplybook therapy webhook functions to include more logs and more safety checks. 

Changes include:
- `client_id` refactored to `user_id` for clarity
- improved logging to make it clear where/why the error happened in future
- ensured cancelled therapy reimburses the correct partner admin
- case insensitive email filtering ```where: `"clientEmail" ILIKE 'testuser@test.com'``` to prevent user matching errors 
- ensured fallback logic to match user to `client_email` or `user_id` is working, should solve all recent related errors

### Why did you make the changes?
There have been several errors related to user not being found, likely due to case matching `user.email` with storyblok `client_email`
