### PR TITLE
Add serviceEmailsPermission field

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ To revert a migration
 yarn migration:revert
 ```
 
+Note that when running the app in Docker, you may need to run migration commands from the docker terminal/Exec
+
 **New environment variables must be added to Heroku before release.**
 
 ### Run unit tests

--- a/package.json
+++ b/package.json
@@ -23,9 +23,10 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js",
     "seed": "bash ./staging_backup.sh -c",
-    "migration:generate": "yarn build && yarn typeorm migration:generate -- -n bloom-backend",
+    "migration:generate": "yarn build && yarn typeorm -- migration:generate -n bloom-backend",
     "migration:run": "yarn build && yarn typeorm -- migration:run",
     "migration:revert": "yarn typeorm -- migration:revert",
+    "migration:show": "yarn build && yarn typeorm -- migration:show",
     "prepare": "husky install"
   },
   "dependencies": {

--- a/src/api/crisp/utils/createCrispProfileData.spec.ts
+++ b/src/api/crisp/utils/createCrispProfileData.spec.ts
@@ -5,6 +5,7 @@ const userDto = {
   name: 'name',
   firebaseUid: 'iiiiod',
   contactPermission: false,
+  serviceEmailsPermission: true,
   id: 'string',
   createdAt: new Date(),
   updatedAt: new Date(),

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -24,8 +24,11 @@ export class UserEntity extends BaseBloomEntity {
   @Column({ nullable: true })
   signUpLanguage: string;
 
-  @Column()
-  contactPermission!: boolean;
+  @Column({ default: false })
+  contactPermission: boolean; // marketing consent
+
+  @Column({ default: true })
+  serviceEmailsPermission: boolean; // service emails consent
 
   @Column({ type: Boolean, default: false })
   isSuperAdmin: boolean;

--- a/src/migrations/1706174260018-bloom-backend.ts
+++ b/src/migrations/1706174260018-bloom-backend.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class bloomBackend1706174260018 implements MigrationInterface {
+  name = 'bloomBackend1706174260018';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD "serviceEmailsPermission" boolean NOT NULL DEFAULT true`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ALTER COLUMN "contactPermission" SET DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" ALTER COLUMN "contactPermission" DROP DEFAULT`);
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "serviceEmailsPermission"`);
+  }
+}

--- a/src/partner-admin/partner-admin-auth.guard.spec.ts
+++ b/src/partner-admin/partner-admin-auth.guard.spec.ts
@@ -16,6 +16,7 @@ const userEntity: UserEntity = {
   email: 'usermail',
   name: 'name',
   contactPermission: false,
+  serviceEmailsPermission: true,
   isSuperAdmin: false,
   crispTokenId: '123',
   partnerAccess: [],

--- a/src/partner-admin/partner-admin.service.ts
+++ b/src/partner-admin/partner-admin.service.ts
@@ -57,6 +57,7 @@ export class PartnerAdminService {
         email,
         firebaseUid: firebaseUser.user.uid,
         contactPermission: true,
+        serviceEmailsPermission: true,
       });
 
       return await this.partnerAdminRepository.save({
@@ -88,7 +89,7 @@ export class PartnerAdminService {
         .update(PartnerAdminEntity)
         .set({ active: updatePartnerAdminDto.active })
         .where('partnerAdminId = :partnerAdminId', { partnerAdminId })
-        .returning('*')
+        .returning('*');
     } catch (error) {
       throw error;
     }

--- a/src/user/dtos/create-user.dto.ts
+++ b/src/user/dtos/create-user.dto.ts
@@ -36,6 +36,11 @@ export class CreateUserDto {
   contactPermission: boolean;
 
   @IsOptional()
+  @IsBoolean()
+  @ApiProperty({ type: Boolean })
+  serviceEmailsPermission: boolean;
+
+  @IsOptional()
   @IsString()
   @ApiProperty({ type: String })
   signUpLanguage: string;

--- a/src/user/dtos/update-user.dto.ts
+++ b/src/user/dtos/update-user.dto.ts
@@ -11,4 +11,9 @@ export class UpdateUserDto {
   @IsOptional()
   @ApiProperty({ type: Boolean })
   contactPermission: boolean;
+
+  @IsBoolean()
+  @IsOptional()
+  @ApiProperty({ type: Boolean })
+  serviceEmailsPermission: boolean;
 }

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -35,12 +35,15 @@ const createUserDto: CreateUserDto = {
   password: 'password',
   name: 'name',
   contactPermission: false,
+  serviceEmailsPermission: true,
   signUpLanguage: 'en',
 };
+
 const createUserRepositoryDto = {
   email: 'user@email.com',
   name: 'name',
   contactPermission: false,
+  serviceEmailsPermission: true,
   signUpLanguage: 'en',
   firebaseUid: mockUserRecord.uid,
 };
@@ -48,6 +51,7 @@ const createUserRepositoryDto = {
 const updateUserDto: UpdateUserDto = {
   name: 'new name',
   contactPermission: true,
+  serviceEmailsPermission: false,
 };
 
 const mockPartnerWithAutomaticAccessCodeFeature = {
@@ -240,6 +244,7 @@ describe('UserService', () => {
       expect(user.name).toBe('new name');
       expect(user.email).toBe('user@email.com');
       expect(user.contactPermission).toBe(true);
+      expect(user.serviceEmailsPermission).toBe(false);
 
       expect(repoSpySave).toBeCalledWith({ ...mockUserEntity, ...updateUserDto });
       expect(repoSpySave).toBeCalled();
@@ -280,6 +285,7 @@ describe('UserService', () => {
         partnerAccess,
         signUpLanguage,
         contactPermission,
+        serviceEmailsPermission,
         courseUser,
         eventLog,
         ...userBase

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -160,7 +160,7 @@ export class UserService {
   }
 
   public async createPublicUser(
-    { name, email, contactPermission, signUpLanguage }: CreateUserDto,
+    { name, email, contactPermission, serviceEmailsPermission, signUpLanguage }: CreateUserDto,
     firebaseUid: string,
   ) {
     try {
@@ -169,6 +169,7 @@ export class UserService {
         email,
         firebaseUid,
         contactPermission,
+        serviceEmailsPermission,
         signUpLanguage,
       });
       const createUserResponse = await this.userRepository.save(createUserObject);
@@ -180,7 +181,14 @@ export class UserService {
   }
 
   public async createPartnerUserWithoutCode(
-    { name, email, contactPermission, signUpLanguage, partnerId }: CreateUserDto,
+    {
+      name,
+      email,
+      contactPermission,
+      serviceEmailsPermission,
+      signUpLanguage,
+      partnerId,
+    }: CreateUserDto,
     firebaseUid: string,
   ) {
     try {
@@ -204,6 +212,7 @@ export class UserService {
         email,
         firebaseUid,
         contactPermission,
+        serviceEmailsPermission,
         signUpLanguage,
       });
 
@@ -223,7 +232,14 @@ export class UserService {
   }
 
   public async createPartnerUserWithCode(
-    { name, email, contactPermission, signUpLanguage, partnerAccessCode }: CreateUserDto,
+    {
+      name,
+      email,
+      contactPermission,
+      serviceEmailsPermission,
+      signUpLanguage,
+      partnerAccessCode,
+    }: CreateUserDto,
     firebaseUid: string,
   ) {
     try {
@@ -236,6 +252,7 @@ export class UserService {
         email,
         firebaseUid,
         contactPermission,
+        serviceEmailsPermission,
         signUpLanguage,
       });
 
@@ -349,6 +366,8 @@ export class UserService {
 
     user.name = updateUserDto?.name ?? user.name;
     user.contactPermission = updateUserDto?.contactPermission ?? user.contactPermission;
+    user.serviceEmailsPermission =
+      updateUserDto?.serviceEmailsPermission ?? user.serviceEmailsPermission;
 
     await this.userRepository.save(user);
 

--- a/src/webhooks/webhooks.service.ts
+++ b/src/webhooks/webhooks.service.ts
@@ -90,6 +90,15 @@ export class WebhooksService {
           continue;
         }
 
+        if (therapySession.user && therapySession.user.serviceEmailsPermission === false) {
+          const emailLog = `Therapy session feedback email not sent as user has disabled service emails [email: ${
+            booking.clientEmail
+          }, session date: ${format(sub(new Date(), { days: 1 }), 'dd/MM/yyyy')}]`;
+          this.logger.log(emailLog);
+          this.slackMessageClient.sendMessageToTherapySlackChannel(emailLog);
+          continue;
+        }
+
         await this.mailchimpClient.sendTherapyFeedbackEmail(booking.clientEmail);
         const emailLog = `First therapy session feedback email sent [email: ${
           booking.clientEmail
@@ -161,6 +170,12 @@ export class WebhooksService {
           // Send a warning as we shouldn't be getting into this situations
           this.logger.warn(
             `sendImpactMeasurementEmail: Skipping sending user Impact Measurement Email [email: ${user.email}]`,
+          );
+          continue;
+        }
+        if (user.serviceEmailsPermission === false) {
+          this.logger.log(
+            `sendImpactMeasurementEmail: Skipped sending user Impact Measurement Email - user has disabled service emails  [email: ${user.email}]`,
           );
           continue;
         }

--- a/test/utils/mockData.ts
+++ b/test/utils/mockData.ts
@@ -135,6 +135,7 @@ export const mockUserEntity: UserEntity = {
   crispTokenId: '123',
   firebaseUid: '123',
   contactPermission: true,
+  serviceEmailsPermission: true,
   email: 'user@email.com',
   name: 'name',
   signUpLanguage: 'en',


### PR DESCRIPTION
### What changes did you make?
Added `serviceEmailsPermission` field to enable users to disable service emails. This field is set to true by default as service emails are considered essential to the service and are not for marketing purposes - we have a separate `contactPermission` field for marketing.

Logic added to `sendImpactMeasurementEmail` and `sendFirstTherapySessionFeedbackEmail` to prevent emails being sent to users with `serviceEmailsPermission = false`, and new tests added for this case

### Why did you make the changes?
Several users have requested for service emails to be disabled - this field is the first step to enabling users to do so. 

Upcoming PRs to complete this feature: 
- add frontend page (e.g. `/account/disable-service-emails`) that upon hitting the page, a request is made to update the users `serviceEmailsPermission = false`. This url can then be added to an unsubscribe link on service emails