### PR TITLE
Fix therapy feedback email case sensitivity

### DIFF
--- a/src/webhooks/webhooks.service.ts
+++ b/src/webhooks/webhooks.service.ts
@@ -128,8 +128,7 @@ export class WebhooksService {
 
   private async isFirstCampaignEmail(email: string, campaign: CAMPAIGN_TYPE) {
     const matchingEntries = await this.emailCampaignRepository.find({
-      email,
-      campaignType: campaign,
+      where: `"email" ILIKE '${email}' AND "campaignType" LIKE '${campaign}'`,
     });
     return matchingEntries.length === 0;
   }


### PR DESCRIPTION
### What changes did you make?
Made `isFirstCampaignEmail` email filtering case insensitive, so the email casing doesn't cause duplicate emails sent by `sendFirstTherapySessionFeedbackEmail`

### Why did you make the changes?
Where users entered their email on a therapy booking once with lowercase "name@" and with "Name@" on a later booking, the user was sent the email twice