### PR TITLE
Fix create partner access save

### DIFF
--- a/src/partner-access/partner-access.service.spec.ts
+++ b/src/partner-access/partner-access.service.spec.ts
@@ -81,23 +81,31 @@ describe('PartnerAccessService', () => {
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
+
   describe('createPartnerAccess', () => {
     it('when supplied with correct data should return access code', async () => {
       const partnerAccessDto = { ...mockPartnerAccessEntityBase, ...createPartnerAccessDto };
+      const expectedPartnerAccess = {
+        ...partnerAccessDto,
+        partnerAdminId,
+        partnerId,
+        accessCode: '123456',
+      };
+
+      const partnerAccessRepositorySpy = jest
+        .spyOn(mockPartnerAccessRepository, 'save')
+        .mockImplementationOnce(jest.fn().mockResolvedValue(expectedPartnerAccess)) as never;
 
       const { ...newPartnerAccess } = await service.createPartnerAccess(
         partnerAccessDto,
         partnerId,
         partnerAdminId,
       );
-      expect(newPartnerAccess).toStrictEqual({
-        ...partnerAccessDto,
-        partnerAdminId,
-        partnerId,
-        accessCode: '123456',
-      });
+      expect(newPartnerAccess).toStrictEqual(expectedPartnerAccess);
       expect(newPartnerAccess.accessCode).toHaveLength(6);
+      expect(partnerAccessRepositorySpy).toHaveBeenCalled();
     });
+
     it('tries again when it creates a code that already exists', async () => {
       const repoSpyCreateQueryBuilder = jest.spyOn(repo, 'createQueryBuilder');
       // Mocks that the accesscode already exists
@@ -116,6 +124,7 @@ describe('PartnerAccessService', () => {
       repoSpyCreateQueryBuilder.mockRestore();
     });
   });
+
   describe('assignPartnerAccess', () => {
     it('should update crisp profile and assign partner access', async () => {
       const repoSpyCreateQueryBuilder = jest.spyOn(repo, 'createQueryBuilder');
@@ -157,6 +166,7 @@ describe('PartnerAccessService', () => {
       });
     });
   });
+
   describe('assignPartnerAccessOnSignUp', () => {
     it('when partnerAccess is supplied, it should create a partner access and assign to user', async () => {
       jest.spyOn(repo, 'createQueryBuilder').mockImplementationOnce(
@@ -177,6 +187,7 @@ describe('PartnerAccessService', () => {
       expect(partnerAccess.featureTherapy).toBeTruthy();
     });
   });
+
   describe('createAndAssignPartnerAccess', () => {
     it('when partnerId is supplied, it should create a partner access and assign to user', async () => {
       const partnerAccess = await service.createAndAssignPartnerAccess(
@@ -192,6 +203,7 @@ describe('PartnerAccessService', () => {
       expect(partnerAccess.featureTherapy).toBeFalsy();
     });
   });
+
   describe('getPartnerAccessCodes', () => {
     it('when no filter dto is supplied, it should return all partner accesses', async () => {
       const partnerAccesses = await service.getPartnerAccessCodes(undefined);
@@ -244,6 +256,7 @@ describe('PartnerAccessService', () => {
       );
     });
   });
+
   describe('getUserTherapySessions', () => {
     it('should return user emails with their total therapy sessions available and an associated access code id', async () => {
       const repoSpyCreateQueryBuilder = jest.spyOn(repo, 'createQueryBuilder');

--- a/src/partner-access/partner-access.service.ts
+++ b/src/partner-access/partner-access.service.ts
@@ -43,7 +43,7 @@ export class PartnerAccessService {
       partnerId,
       accessCode,
     };
-    return await this.partnerAccessRepository.create(partnerAccess);
+    return await this.partnerAccessRepository.save(partnerAccess);
   }
 
   private async generateAccessCode(length: number): Promise<string> {

--- a/src/partner-access/partner-access.service.ts
+++ b/src/partner-access/partner-access.service.ts
@@ -37,12 +37,12 @@ export class PartnerAccessService {
     partnerAdminId: string | null,
   ): Promise<PartnerAccessEntity> {
     const accessCode = await this.generateAccessCode(6);
-    const partnerAccess = {
+    const partnerAccess = this.partnerAccessRepository.create({
       ...createPartnerAccessDto,
       partnerAdminId,
       partnerId,
       accessCode,
-    };
+    });
     return await this.partnerAccessRepository.save(partnerAccess);
   }
 


### PR DESCRIPTION
### What changes did you make?
Fixes `.create` to `.save` on createPartnerAccess` function

### Why did you make the changes?
Follow up fix from bug created in previous PR #405 pre merge to production
