### PR TITLE
Update depreciated jest methods

### DIFF
--- a/src/partner-access/partner-access.service.spec.ts
+++ b/src/partner-access/partner-access.service.spec.ts
@@ -120,7 +120,7 @@ describe('PartnerAccessService', () => {
         );
 
       await service.createPartnerAccess(createPartnerAccessDto, partnerId, partnerAdminId);
-      expect(repoSpyCreateQueryBuilder).toBeCalledTimes(2);
+      expect(repoSpyCreateQueryBuilder).toHaveBeenCalledTimes(2);
       repoSpyCreateQueryBuilder.mockRestore();
     });
   });
@@ -141,7 +141,7 @@ describe('PartnerAccessService', () => {
         activatedAt: partnerAccess.activatedAt, // need to just fudge this as it is test specific
       });
 
-      expect(crispApi.updateCrispProfileAccesses).toBeCalledWith(
+      expect(crispApi.updateCrispProfileAccesses).toHaveBeenCalledWith(
         mockGetUserDto.user,
         [partnerAccess],
         [],
@@ -246,14 +246,10 @@ describe('PartnerAccessService', () => {
           }),
         }) as never,
       );
-      await expect(service.getValidPartnerAccessCode('123456')).rejects.toThrowError(
-        'CODE_EXPIRED',
-      );
+      await expect(service.getValidPartnerAccessCode('123456')).rejects.toThrow('CODE_EXPIRED');
     });
     it('when an partner access with too many letters is supplied, it should throw error', async () => {
-      await expect(service.getValidPartnerAccessCode('1234567')).rejects.toThrowError(
-        'INVALID_CODE',
-      );
+      await expect(service.getValidPartnerAccessCode('1234567')).rejects.toThrow('INVALID_CODE');
     });
   });
 
@@ -295,7 +291,7 @@ describe('PartnerAccessService', () => {
       } as UpdatePartnerAccessDto);
       //if an access code exists then update it.
       expect(result).toEqual({ ...mockPartnerAccessEntity, therapySessionsRemaining: 10 });
-      expect(partnerAccessRepositorySpy).toBeCalledTimes(1);
+      expect(partnerAccessRepositorySpy).toHaveBeenCalled();
     });
   });
 });

--- a/src/partner-admin/partner-admin.service.spec.ts
+++ b/src/partner-admin/partner-admin.service.spec.ts
@@ -81,7 +81,7 @@ describe('PartnerAdminService', () => {
       const response = await service.createPartnerAdminUser(dto);
       expect(response).toHaveProperty('partnerId', dto.partnerId);
       expect(response).toHaveProperty('userId', mockUserEntity.id);
-      expect(repoSpySave).toBeCalled();
+      expect(repoSpySave).toHaveBeenCalled();
     });
   });
   it('when supplied with an email that already exists, it should throw', async () => {

--- a/src/partner-feature/partner-feature.service.spec.ts
+++ b/src/partner-feature/partner-feature.service.spec.ts
@@ -81,13 +81,13 @@ describe('PartnerFeatureService', () => {
       jest.spyOn(mockFeatureService, 'getFeature').mockImplementationOnce(() => {
         return undefined;
       });
-      await expect(service.createPartnerFeature(createPartnerFeatureDto)).rejects.toThrowError();
+      await expect(service.createPartnerFeature(createPartnerFeatureDto)).rejects.toThrow();
     });
     it('when supplied with incorrect partnerId should throw', async () => {
       jest.spyOn(mockPartnerService, 'getPartnerById').mockImplementationOnce(() => {
         return undefined;
       });
-      await expect(service.createPartnerFeature(createPartnerFeatureDto)).rejects.toThrowError();
+      await expect(service.createPartnerFeature(createPartnerFeatureDto)).rejects.toThrow();
     });
   });
   describe('getAutomaticAccessCodeFeatureForPartner', () => {
@@ -106,7 +106,7 @@ describe('PartnerFeatureService', () => {
     });
     it('when supplied with incorrect partner name, it should throw', async () => {
       jest.spyOn(mockPartnerService, 'getPartner').mockImplementationOnce(() => undefined);
-      await expect(service.getAutomaticAccessCodeFeatureForPartner('Badoo')).rejects.toThrowError(
+      await expect(service.getAutomaticAccessCodeFeatureForPartner('Badoo')).rejects.toThrow(
         'Unable to find partner with that name',
       );
     });
@@ -130,7 +130,7 @@ describe('PartnerFeatureService', () => {
 
       await expect(
         service.updatePartnerFeature('partnerFeatureId', { active: false }),
-      ).rejects.toThrowError('Error unable to update');
+      ).rejects.toThrow('Error unable to update');
     });
   });
 });

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -124,9 +124,9 @@ describe('UserService', () => {
       expect(user.user.email).toBe('user@email.com');
       expect(user.partnerAdmin).toBeUndefined();
       expect(user.partnerAccesses).toBe(undefined);
-      expect(repoSpyCreate).toBeCalledWith(createUserRepositoryDto);
-      expect(repoSpySave).toBeCalled();
-      expect(addCrispProfile).toBeCalledWith({
+      expect(repoSpyCreate).toHaveBeenCalledWith(createUserRepositoryDto);
+      expect(repoSpySave).toHaveBeenCalled();
+      expect(addCrispProfile).toHaveBeenCalledWith({
         email: user.user.email,
         person: { nickname: 'name' },
         segments: ['public'],
@@ -155,11 +155,11 @@ describe('UserService', () => {
         { ...partnerAccessData, therapySessions: therapySession },
       ]);
 
-      expect(repoSpyCreate).toBeCalledWith(createUserRepositoryDto);
-      expect(partnerAccessSpy).toBeCalled();
-      expect(repoSpySave).toBeCalled();
+      expect(repoSpyCreate).toHaveBeenCalledWith(createUserRepositoryDto);
+      expect(partnerAccessSpy).toHaveBeenCalled();
+      expect(repoSpySave).toHaveBeenCalled();
 
-      expect(addCrispProfile).toBeCalledWith({
+      expect(addCrispProfile).toHaveBeenCalledWith({
         email: user.user.email,
         person: { nickname: 'name' },
         segments: ['bumble'],
@@ -177,8 +177,8 @@ describe('UserService', () => {
       await expect(async () => {
         await service.createUser({ ...createUserDto, partnerAccessCode: '123456' });
       }).rejects.toThrow(PartnerAccessCodeStatusEnum.ALREADY_IN_USE);
-      expect(userRepoSpy).toBeCalledTimes(0);
-      expect(assignCodeSpy).toBeCalledTimes(0);
+      expect(userRepoSpy).not.toHaveBeenCalled();
+      expect(assignCodeSpy).not.toHaveBeenCalled();
     });
     // TODO - what do we want to happen here?
     it('when supplied with user dto and partner access that is incorrect, it should throw an error', async () => {
@@ -190,8 +190,8 @@ describe('UserService', () => {
         });
       await expect(
         service.createUser({ ...createUserDto, partnerAccessCode: 'incorrect code' }),
-      ).rejects.toThrowError('Access code invalid');
-      expect(userRepoSpy).toBeCalledTimes(0);
+      ).rejects.toThrow('Access code invalid');
+      expect(userRepoSpy).not.toHaveBeenCalled();
     });
 
     it('when supplied with user dto and partnerId but no partner access code, it should return a user with partner access', async () => {
@@ -250,8 +250,8 @@ describe('UserService', () => {
       expect(user.contactPermission).toBe(true);
       expect(user.serviceEmailsPermission).toBe(false);
 
-      expect(repoSpySave).toBeCalledWith({ ...mockUserEntity, ...updateUserDto });
-      expect(repoSpySave).toBeCalled();
+      expect(repoSpySave).toHaveBeenCalledWith({ ...mockUserEntity, ...updateUserDto });
+      expect(repoSpySave).toHaveBeenCalled();
     });
   });
 
@@ -274,7 +274,7 @@ describe('UserService', () => {
       expect(user.name).not.toBe(mockUserEntity.name);
       expect(user.email).not.toBe(mockUserEntity.email);
 
-      expect(repoSpySave).toBeCalled();
+      expect(repoSpySave).toHaveBeenCalled();
     });
   });
 

--- a/src/webhooks/webhooks.service.spec.ts
+++ b/src/webhooks/webhooks.service.spec.ts
@@ -228,7 +228,7 @@ describe('WebhooksService', () => {
         text: '',
       };
 
-      return expect(service.updateStory(body, getWebhookSignature(body))).rejects.toThrowError(
+      return expect(service.updateStory(body, getWebhookSignature(body))).rejects.toThrow(
         'STORYBLOK STORY NOT FOUND',
       );
     });
@@ -308,7 +308,7 @@ describe('WebhooksService', () => {
 
       const session = (await service.updateStory(body, getWebhookSignature(body))) as SessionEntity;
 
-      expect(courseFindOneSpy).toBeCalledWith({
+      expect(courseFindOneSpy).toHaveBeenCalledWith({
         storyblokUuid: 'anotherCourseUuId',
       });
 
@@ -318,13 +318,13 @@ describe('WebhooksService', () => {
         courseId: 'courseId2',
       });
 
-      expect(sessionSaveRepoSpy).toBeCalledWith({
+      expect(sessionSaveRepoSpy).toHaveBeenCalledWith({
         ...mockSession,
         courseId: 'courseId2',
         course: course2,
       });
 
-      expect(sessionFindOneRepoSpy).toBeCalledWith({
+      expect(sessionFindOneRepoSpy).toHaveBeenCalledWith({
         storyblokId: mockSession.storyblokId,
       });
 
@@ -352,16 +352,16 @@ describe('WebhooksService', () => {
       const session = (await service.updateStory(body, getWebhookSignature(body))) as SessionEntity;
 
       expect(session).toEqual(mockSession);
-      expect(courseFindOneSpy).toBeCalledWith({
+      expect(courseFindOneSpy).toHaveBeenCalledWith({
         storyblokUuid: 'courseUuid1',
       });
-      expect(sessionSaveRepoSpy).toBeCalledWith({
+      expect(sessionSaveRepoSpy).toHaveBeenCalledWith({
         ...mockSession,
       });
-      expect(sessionSaveRepoSpy).toBeCalledWith({
+      expect(sessionSaveRepoSpy).toHaveBeenCalledWith({
         ...mockSession,
       });
-      expect(sessionFindOneRepoSpy).toBeCalledWith({
+      expect(sessionFindOneRepoSpy).toHaveBeenCalledWith({
         storyblokId: mockSession.storyblokId,
       });
 
@@ -411,7 +411,7 @@ describe('WebhooksService', () => {
       const session = (await service.updateStory(body, getWebhookSignature(body))) as SessionEntity;
 
       expect(session).toEqual(mockSession);
-      expect(sessionSaveRepoSpy).toBeCalledWith({
+      expect(sessionSaveRepoSpy).toHaveBeenCalledWith({
         ...mockSession,
       });
 
@@ -445,11 +445,11 @@ describe('WebhooksService', () => {
       const course = (await service.updateStory(body, getWebhookSignature(body))) as CourseEntity;
 
       expect(course).toEqual(mockCourse);
-      expect(courseFindOneRepoSpy).toBeCalledWith({
+      expect(courseFindOneRepoSpy).toHaveBeenCalledWith({
         storyblokId: mockCourseStoryblokResult.data.story.id,
       });
 
-      expect(courseCreateRepoSpy).toBeCalledWith({
+      expect(courseCreateRepoSpy).toHaveBeenCalledWith({
         storyblokId: mockCourseStoryblokResult.data.story.id,
         name: mockCourseStoryblokResult.data.story.name,
         status: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
@@ -457,7 +457,7 @@ describe('WebhooksService', () => {
         storyblokUuid: mockCourseStoryblokResult.data.story.uuid,
       });
 
-      expect(courseSaveRepoSpy).toBeCalledWith(mockCourse);
+      expect(courseSaveRepoSpy).toHaveBeenCalledWith(mockCourse);
 
       courseFindOneRepoSpy.mockClear();
       courseCreateRepoSpy.mockClear();
@@ -478,17 +478,17 @@ describe('WebhooksService', () => {
       });
       expect(booking).toHaveProperty('startDateTime', new Date(newStartTime));
       expect(booking).toHaveProperty('endDateTime', new Date(newEndTime));
-      expect(therapyRepoFindOneSpy).toBeCalled();
+      expect(therapyRepoFindOneSpy).toHaveBeenCalled();
     });
 
     it('should throw an error when action is on a user that doesnt exist', async () => {
       const userFindOneRepoSpy = jest
         .spyOn(mockedUserRepository, 'findOneBy')
         .mockImplementationOnce(() => undefined);
-      await expect(service.updatePartnerAccessTherapy(mockSimplybookBodyBase)).rejects.toThrowError(
+      await expect(service.updatePartnerAccessTherapy(mockSimplybookBodyBase)).rejects.toThrow(
         'UpdatePartnerAccessTherapy - error finding user with userID userId2 and origin client_email testuser@test.com',
       );
-      expect(userFindOneRepoSpy).toBeCalled();
+      expect(userFindOneRepoSpy).toHaveBeenCalled();
     });
 
     it('when creating a new therapy session and the userId is not provided, it should get userId from previous entry', async () => {
@@ -517,12 +517,12 @@ describe('WebhooksService', () => {
         endDateTime: new Date(mockSimplybookBodyBase.end_date_time),
       });
 
-      expect(findTherapySessionSpy).toBeCalledWith({
+      expect(findTherapySessionSpy).toHaveBeenCalledWith({
         clientEmail: ILike('testuser@test.com'),
         bookingCode: ILike('abc'),
       });
 
-      expect(findPartnerAccessSpy).toBeCalledWith({
+      expect(findPartnerAccessSpy).toHaveBeenCalledWith({
         userId: 'userId1',
         featureTherapy: true,
         active: true,
@@ -557,15 +557,15 @@ describe('WebhooksService', () => {
         endDateTime: new Date(mockSimplybookBodyBase.end_date_time),
       });
 
-      expect(findTherapySessionSpy).toBeCalledWith({
+      expect(findTherapySessionSpy).toHaveBeenCalledWith({
         clientEmail: ILike('testuser@test.com'),
         bookingCode: ILike('abc'),
       });
-      expect(findUserSpy).toBeCalledWith({
+      expect(findUserSpy).toHaveBeenCalledWith({
         id: 'userId1',
       });
 
-      expect(findPartnerAccessSpy).toBeCalledWith({
+      expect(findPartnerAccessSpy).toHaveBeenCalledWith({
         userId: 'userId1',
         featureTherapy: true,
         active: true,
@@ -598,7 +598,7 @@ describe('WebhooksService', () => {
           ...{ action: SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING },
         }),
       ).resolves.toHaveProperty('action', SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING);
-      expect(partnerAccessSaveSpy).toBeCalledWith({
+      expect(partnerAccessSaveSpy).toHaveBeenCalledWith({
         ...mockPartnerAccessEntity,
         therapySessionsRemaining: mockPartnerAccessEntity.therapySessionsRemaining + 1,
         therapySessionsRedeemed: mockPartnerAccessEntity.therapySessionsRedeemed - 1,
@@ -618,7 +618,7 @@ describe('WebhooksService', () => {
           ...{ action: SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING },
         }),
       ).resolves.toHaveProperty('action', SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING);
-      expect(partnerAccessFindSpy).toBeCalled();
+      expect(partnerAccessFindSpy).toHaveBeenCalled();
     });
 
     it('should throw if no partnerAccess exists when user tries to create a booking', async () => {
@@ -649,7 +649,7 @@ describe('WebhooksService', () => {
           ...{ action: SIMPLYBOOK_ACTION_ENUM.NEW_BOOKING },
         }),
       ).resolves.toHaveProperty('action', SIMPLYBOOK_ACTION_ENUM.NEW_BOOKING);
-      expect(partnerAccessSaveSpy).toBeCalledWith(mockPartnerAccessEntity);
+      expect(partnerAccessSaveSpy).toHaveBeenCalledWith(mockPartnerAccessEntity);
     });
     it('should not update partner access when user updates booking', async () => {
       const partnerAccessSaveSpy = jest.spyOn(mockedPartnerAccessRepository, 'save');
@@ -659,7 +659,7 @@ describe('WebhooksService', () => {
           ...{ action: SIMPLYBOOK_ACTION_ENUM.UPDATED_BOOKING },
         }),
       ).resolves.toHaveProperty('action', SIMPLYBOOK_ACTION_ENUM.UPDATED_BOOKING);
-      expect(partnerAccessSaveSpy).toBeCalledTimes(0);
+      expect(partnerAccessSaveSpy).not.toHaveBeenCalled();
     });
     it('should error if user creates booking when no therapy sessions remaining ', async () => {
       jest.spyOn(mockedPartnerAccessRepository, 'findBy').mockImplementationOnce(async () => {
@@ -677,7 +677,7 @@ describe('WebhooksService', () => {
           ...mockSimplybookBodyBase,
           ...{ action: SIMPLYBOOK_ACTION_ENUM.NEW_BOOKING },
         }),
-      ).rejects.toThrowError(
+      ).rejects.toThrow(
         'newPartnerAccessTherapy - user has partner therapy access but has 0 therapy sessions remaining - email user@email.com userId userId2',
       );
     });
@@ -712,7 +712,7 @@ describe('WebhooksService', () => {
           ...{ action: SIMPLYBOOK_ACTION_ENUM.UPDATED_BOOKING },
         }),
       ).resolves.toHaveProperty('action', SIMPLYBOOK_ACTION_ENUM.UPDATED_BOOKING);
-      expect(therapySessionFindOneSpy).toBeCalledTimes(1);
+      expect(therapySessionFindOneSpy).toHaveBeenCalled();
     });
   });
   describe('sendFirstTherapySessionFeedbackEmail', () => {
@@ -746,8 +746,8 @@ describe('WebhooksService', () => {
           'dd/MM/yyyy',
         )}`,
       );
-      await expect(mailChimpSpy).toBeCalledTimes(0);
-      await expect(saveSpy).toBeCalledTimes(0);
+      await expect(mailChimpSpy).not.toHaveBeenCalled();
+      await expect(saveSpy).not.toHaveBeenCalled();
     });
 
     it('should only send emails to users who have signed up in english', async () => {
@@ -812,9 +812,9 @@ describe('WebhooksService', () => {
           'dd/MM/yyyy',
         )} - ${format(endDate, 'dd/MM/yyyy')}`,
       );
-      expect(mailChimpSpy).toBeCalledTimes(2);
-      expect(emailCampaignRepositorySpy).toBeCalledTimes(2);
-      expect(emailCampaignRepositoryFindSpy).toBeCalledTimes(2);
+      expect(mailChimpSpy).toHaveBeenCalledTimes(2);
+      expect(emailCampaignRepositorySpy).toHaveBeenCalledTimes(2);
+      expect(emailCampaignRepositoryFindSpy).toHaveBeenCalledTimes(2);
     });
 
     it('if error occurs for saving entry in campaign repository for one user, loop continues and error is logged', async () => {
@@ -841,9 +841,9 @@ describe('WebhooksService', () => {
           'dd/MM/yyyy',
         )} - ${format(endDate, 'dd/MM/yyyy')}`,
       );
-      expect(mailChimpSpy).toBeCalledTimes(2);
-      expect(emailCampaignRepositorySpy).toBeCalledTimes(2);
-      expect(emailCampaignRepositoryFindSpy).toBeCalledTimes(2);
+      expect(mailChimpSpy).toHaveBeenCalledTimes(2);
+      expect(emailCampaignRepositorySpy).toHaveBeenCalledTimes(2);
+      expect(emailCampaignRepositoryFindSpy).toHaveBeenCalledTimes(2);
     });
 
     it('if error occurs for sending email for one user, loop continues', async () => {
@@ -870,9 +870,9 @@ describe('WebhooksService', () => {
           'dd/MM/yyyy',
         )} - ${format(endDate, 'dd/MM/yyyy')}`,
       );
-      expect(mailChimpSpy).toBeCalledTimes(2);
-      expect(emailCampaignRepositorySpy).toBeCalledTimes(1);
-      expect(emailCampaignRepositoryFindSpy).toBeCalledTimes(2);
+      expect(mailChimpSpy).toHaveBeenCalledTimes(2);
+      expect(emailCampaignRepositorySpy).toHaveBeenCalled();
+      expect(emailCampaignRepositoryFindSpy).toHaveBeenCalledTimes(2);
     });
 
     it('if a user has already been sent an email, no second email is sent', async () => {
@@ -896,8 +896,8 @@ describe('WebhooksService', () => {
           'dd/MM/yyyy',
         )} - ${format(endDate, 'dd/MM/yyyy')}`,
       );
-      expect(emailCampaignRepositorySpy).toBeCalledTimes(1);
-      expect(emailCampaignRepositoryFindSpy).toBeCalledTimes(2);
+      expect(emailCampaignRepositorySpy).toHaveBeenCalled();
+      expect(emailCampaignRepositoryFindSpy).toHaveBeenCalledTimes(2);
     });
 
     it('if a user disabled service emails, no email is sent', async () => {
@@ -921,14 +921,14 @@ describe('WebhooksService', () => {
           'dd/MM/yyyy',
         )} - ${format(endDate, 'dd/MM/yyyy')}`,
       );
-      expect(emailCampaignRepositorySpy).toBeCalledTimes(0);
+      expect(emailCampaignRepositorySpy).not.toHaveBeenCalled();
     });
 
     it('if error occurs fetching users, error is thrown', async () => {
       jest.spyOn(mockedUserRepository, 'findBy').mockImplementationOnce(async () => {
         throw new Error('Failed to save');
       });
-      await expect(service.sendImpactMeasurementEmail()).rejects.toThrowError(
+      await expect(service.sendImpactMeasurementEmail()).rejects.toThrow(
         'SendImpactMeasurementEmail - Unable to fetch user',
       );
     });
@@ -960,7 +960,7 @@ describe('WebhooksService', () => {
         return null;
       });
 
-      await expect(service.createEventLog(eventDto)).rejects.toThrowError(
+      await expect(service.createEventLog(eventDto)).rejects.toThrow(
         `createEventLog webhook failed - no user attached to email a@b.com`,
       );
     });
@@ -974,7 +974,7 @@ describe('WebhooksService', () => {
         throw new Error('Unable to create event log error');
       });
 
-      await expect(service.createEventLog(eventDto)).rejects.toThrowError(
+      await expect(service.createEventLog(eventDto)).rejects.toThrow(
         `Unable to create event log error`,
       );
     });


### PR DESCRIPTION
### What changes did you make?
Replaced depreciated jest methods
`toBeCalled()` -> `toHaveBeenCalled()`
`toBeCalledWith(...)` -> `toHaveBeenCalledWith(...)`
`toBeCalledTimes(2)` -> `toHaveBeenCalledTimes(2)`
`toThrowError(...)` -> `toThrow(...)`


### Why did you make the changes?
Following dependency update in #405 