### PR TITLE
Fix new relic CI region

### DIFF
--- a/.github/workflows/newrelic-release-tracking.yml
+++ b/.github/workflows/newrelic-release-tracking.yml
@@ -17,7 +17,7 @@ jobs:
         uses: newrelic/deployment-marker-action@v2.2.0
         with:
           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
-          region: 'US'
+          region: 'EU'
           guid: ${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}
           version: '${{ env.COMMIT_REF }}'
           user: '${{ github.actor }}'


### PR DESCRIPTION
### What changes did you make?
Updated the region value to `EU` on the New relic release tracking action

### Why did you make the changes?
New relic CI action for release tracking was failing due to region set to legacy US