### PR TITLE
Fix getUsers function

### DIFF
--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -293,11 +293,9 @@ describe('UserService', () => {
         eventLog,
         ...userBase
       } = mockUserEntity;
-      jest.spyOn(repo, 'createQueryBuilder').mockImplementationOnce(
-        createQueryBuilderMock({
-          getMany: jest.fn().mockResolvedValue([{ ...mockUserEntity, email: 'a@b.com' }]),
-        }) as never,
-      );
+      jest
+        .spyOn(repo, 'find')
+        .mockImplementationOnce(async () => [{ ...mockUserEntity, email: 'a@b.com' }]);
       const users = await service.getUsers({ email: 'a@b.com' }, {}, [], 10);
       expect(users).toEqual([{ user: { ...userBase, email: 'a@b.com' }, partnerAccesses: [] }]);
     });

--- a/test/utils/mockedServices.ts
+++ b/test/utils/mockedServices.ts
@@ -197,6 +197,9 @@ export const mockUserRepositoryMethodsFactory = {
       ...dto,
     };
   },
+  find: async () => {
+    return [mockUserEntity];
+  },
   findOneBy: ({ email: client_email }) => {
     return { ...mockUserEntity, ...(client_email ? { email: client_email } : {}) };
   },


### PR DESCRIPTION
### What changes did you make?
Refactored the query builder in `getUsers` function, to use `find` and conditional parameters

### Why did you make the changes?
Following typeorm 0.2.0 -> 0.3.0 update in #405 , calling `getUsers` resulted in the error:
`ERROR [error] Failed GET "/api/v1/user?searchCriteria=%7B%22email%22%3A%22tech%2B1111%40chayn.co%22%2C%22partnerAccess%22%3A%7B%22featureTherapy%22%3Atrue%2C%22active%22%3Atrue%7D%2C%22include%22%3A%5B%22partnerAccess%22%5D%2C%22fields%22%3A%5B%22partnerAccess%22%5D%2C%22limit%22%3A%2210%22%7D" for ::ffff:192.168.65.1 - status: undefined, message: missing FROM-clause entry for table "partneraccess"`

There seems to be an issue using left joins on `user.partnerAccess` in this case, but there were no errors using `.find`