### PR TITLE
Fix get users query partial email

### DIFF
--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -410,7 +410,7 @@ export class UserService {
     const users = await this.userRepository.find({
       relations: relations,
       where: {
-        ...(filters.email && { email: ILike(filters.email) }),
+        ...(filters.email && { email: ILike(`%${filters.email}%`) }),
         ...(filters.partnerAccess && {
           partnerAccess: {
             ...(filters.partnerAccess.userId && { userId: filters.partnerAccess.userId }),


### PR DESCRIPTION
### What changes did you make?
Replaced partial email search on the `getUsers` function

### Why did you make the changes?
This was the original functionality (to allow partial email search) but was unintentially degraded in #410 