### PR TITLE
Added Get api endpoint for getting user profile

### DIFF
--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -41,9 +41,25 @@ export class UserController {
     description:
       'Returns user profile data with their nested partner access, partner admin, course user and session user data.',
   })
-  @Post('/me')
+  @Get('/me')
   @UseGuards(FirebaseAuthGuard)
   async getUserByFirebaseId(@Req() req: Request): Promise<GetUserDto> {
+    return req['user'];
+  }
+
+  /**
+   * This POST endpoint deviates from REST patterns.
+   * Please use `getUserByFirebaseId` above which is a GET endpoint.
+   * Do not delete this until frontend usage is migrated.
+   */
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    description:
+      'Returns user profile data with their nested partner access, partner admin, course user and session user data.',
+  })
+  @Post('/me')
+  @UseGuards(FirebaseAuthGuard)
+  async getUserProfileByFirebaseId(@Req() req: Request): Promise<GetUserDto> {
     return req['user'];
   }
 


### PR DESCRIPTION
### Issue link / number:
https://github.com/chaynHQ/bloom-backend/issues/417

### What changes did you make?
Added `GET` method endpoint for `/v1/user/me` to align with REST standards

### Why did you make the changes?
Currently `/v1/user/me` endpoint deviates from REST patterns, therefore we have added a `GET` endpoint for the same. The current `POST` endpoint will be removed once the new `GET` endpoint is implemented on the front end.

<!--- PR CHECKLIST: PLEASE REMOVE BEFORE SUBMITTING —>
Before submitting, check that you have completed the following tasks:
- [ ] Answered the questions above.
- [ ] Read Chayn's Contributing Guidelines in the CONTRIBUTING.md file.
- [ ] Enabled "Allow edits and access to secrets by maintainers" on this PR.
- [ ] If applicable, include images in the description.
After submitting, please be available for discussion. Thank you!
