### PR TITLE
Add test cases for createPartner

### DIFF
--- a/src/partner/partner.service.spec.ts
+++ b/src/partner/partner.service.spec.ts
@@ -1,0 +1,62 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { PartnerEntity } from '../entities/partner.entity';
+import { PartnerService } from './partner.service';
+import { Repository } from 'typeorm';
+import { PartnerAccessEntity } from '../entities/partner-access.entity';
+import { PartnerAdminEntity } from '../entities/partner-admin.entity';
+import { UserEntity } from '../entities/user.entity';
+import { mockPartnerRepositoryMethods } from '../../test/utils/mockedServices';
+import { mockPartnerEntity } from '../../test/utils/mockData';
+
+const createPartnerDto = {
+  name: mockPartnerEntity.name,
+};
+describe('PartnerService', () => {
+  let service: PartnerService;
+  let mockPartnerRepository: DeepMocked<Repository<PartnerEntity>>;
+  let mockPartnerAccessRepository: DeepMocked<Repository<PartnerAccessEntity>>;
+  let mockPartnerAdminRepository: DeepMocked<Repository<PartnerAdminEntity>>;
+  let mockUserRepository: DeepMocked<Repository<UserEntity>>;
+
+  beforeEach(async () => {
+    mockPartnerRepository = createMock<Repository<PartnerEntity>>(
+      mockPartnerRepositoryMethods,
+    );
+    mockPartnerAccessRepository = createMock<Repository<PartnerAccessEntity>>();
+    mockPartnerAdminRepository = createMock<Repository<PartnerAdminEntity>>();
+    mockUserRepository = createMock<Repository<UserEntity>>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PartnerService,
+        { provide: getRepositoryToken(PartnerEntity), useValue: mockPartnerRepository },
+        { provide: getRepositoryToken(PartnerAccessEntity), useValue: mockPartnerAccessRepository },
+        { provide: getRepositoryToken(PartnerAdminEntity), useValue: mockPartnerAdminRepository },
+        { provide: getRepositoryToken(UserEntity), useValue: mockUserRepository },
+      ],
+    }).compile();
+
+    service = module.get<PartnerService>(PartnerService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('createPartner', () => {
+    it('when supplied with correct data should return new partner', async () => {
+      const response = await service.createPartner(createPartnerDto);
+      expect(response).toMatchObject(createPartnerDto);
+    })
+    it('when supplied with a name that already exists, it should throw error', async () => {
+      jest
+        .spyOn(mockPartnerRepository, 'create')
+        .mockImplementationOnce(() => {
+          throw ({ code: '23505' });
+        });
+      await expect(service.createPartner(createPartnerDto)).rejects.toThrow();
+    })
+  });
+});


### PR DESCRIPTION
### Issue link / number:
https://github.com/chaynHQ/bloom-backend/issues/420
### What changes did you make?
Added test scenarios partnerService.createPartner passes and fails
Looked at other test files such as `partner-admin.service.spec.ts` and `partner-feature.service.spec.ts` for references
### Why did you make the changes?
To ensure this logic works correctly

<!--- PR CHECKLIST: PLEASE REMOVE BEFORE SUBMITTING —>
Before submitting, check that you have completed the following tasks:
- [ ] Answered the questions above.
- [ ] Read Chayn's Contributing Guidelines in the CONTRIBUTING.md file.
- [ ] Enabled "Allow edits and access to secrets by maintainers" on this PR.
- [ ] If applicable, include images in the description.
After submitting, please be available for discussion. Thank you!
