### PR TITLE
Fix service user profiles throw error

### DIFF
--- a/src/utils/serviceUserProfiles.ts
+++ b/src/utils/serviceUserProfiles.ts
@@ -78,7 +78,6 @@ export const createServiceUserProfiles = async (
     logger.log(`Create user: updated service user profiles. User: ${email}`);
   } catch (error) {
     logger.error(`Create service user profiles error - ${error}. User: ${email}`);
-    throw error;
   }
 };
 


### PR DESCRIPTION
### What changes did you make?
Remove `throw error` from `createServiceUserProfiles` function. The service user profiles functions support our external comms profiles (mailchimp and crisp), however if there is an error creating or updating these external profiles, we don't want the original database/api route to fail. I.e. a users sign up request should not error due to crisp profile creation error, we should catch and log these errors only, but allow the api route to succeed.

### Why did you make the changes?
This is a new bug accidentally introduced in #428 , fixing so it doesn't cause errors on user sign up