### PR TITLE
Add event logger controller

### DIFF
--- a/src/event-logger/event-logger.controller.ts
+++ b/src/event-logger/event-logger.controller.ts
@@ -1,0 +1,28 @@
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { FirebaseAuthGuard } from 'src/firebase/firebase-auth.guard';
+import { ControllerDecorator } from 'src/utils/controller.decorator';
+import { EVENT_NAME } from './event-logger.interface';
+import { EventLoggerService } from './event-logger.service';
+
+@ApiTags('Event Logger')
+@ControllerDecorator()
+@Controller('/v1/event-logger')
+export class EventLoggerController {
+  constructor(private readonly eventLoggerService: EventLoggerService) {}
+
+  @Post()
+  @ApiOperation({
+    description: 'Creates an event log',
+  })
+  @ApiBearerAuth('access-token')
+  @UseGuards(FirebaseAuthGuard)
+  async complete(@Req() req: Request, @Body() event: EVENT_NAME) {
+    const now = new Date();
+    return await this.eventLoggerService.createEventLog({
+      userId: req['userEntity'].id,
+      event,
+      date: now,
+    });
+  }
+}

--- a/src/event-logger/event-logger.interface.ts
+++ b/src/event-logger/event-logger.interface.ts
@@ -1,5 +1,7 @@
 export enum EVENT_NAME {
   CHAT_MESSAGE_SENT = 'CHAT_MESSAGE_SENT',
+  LOGGED_IN = 'LOGGED_IN',
+  LOGGED_OUT = 'LOGGED_OUT',
 }
 
 export interface ICreateEventLog {


### PR DESCRIPTION
### What changes did you make?
Added event logger controller and new login/logout events. 

We can now send event logger events from the frontend - a user token is required. 

### Why did you make the changes?
To support login/logout events and `userLastActive`, to be used in mailchimp email reminders