### PR TITLE
Improve create user firebase error reporting

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -7,12 +7,7 @@ import {
 } from '@nestjs/common';
 import { DecodedIdToken } from 'firebase-admin/lib/auth/token-verifier';
 import { Logger } from 'src/logger/logger';
-import {
-  CREATE_USER_ALREADY_EXISTS,
-  CREATE_USER_FIREBASE_ERROR,
-  CREATE_USER_INVALID_EMAIL,
-  CREATE_USER_WEAK_PASSWORD,
-} from 'src/utils/errors';
+import { FIREBASE_ERRORS } from 'src/utils/errors';
 import { FIREBASE } from '../firebase/firebase-factory';
 import { FirebaseServices } from '../firebase/firebase.types';
 import { UserAuthDto } from './dto/user-auth.dto';
@@ -61,19 +56,19 @@ export class AuthService {
         this.logger.warn(
           `Create user: user tried to create email with invalid email: ${email} - ${err}`,
         );
-        throw new HttpException(CREATE_USER_INVALID_EMAIL, HttpStatus.BAD_REQUEST);
+        throw new HttpException(FIREBASE_ERRORS.CREATE_USER_INVALID_EMAIL, HttpStatus.BAD_REQUEST);
       } else if (errorCode === 'auth/weak-password' || errorCode === 'auth/invalid-password') {
         this.logger.warn(`Create user: user tried to create email with weak password - ${err}`);
-        throw new HttpException(CREATE_USER_WEAK_PASSWORD, HttpStatus.BAD_REQUEST);
+        throw new HttpException(FIREBASE_ERRORS.CREATE_USER_WEAK_PASSWORD, HttpStatus.BAD_REQUEST);
       } else if (
         errorCode === 'auth/email-already-in-use' ||
         errorCode === 'auth/email-already-exists'
       ) {
         this.logger.warn(`Create user: Firebase user already exists: ${email}`);
-        throw new HttpException(CREATE_USER_ALREADY_EXISTS, HttpStatus.BAD_REQUEST);
+        throw new HttpException(FIREBASE_ERRORS.CREATE_USER_ALREADY_EXISTS, HttpStatus.BAD_REQUEST);
       } else {
         this.logger.error(`Create user: Error creating firebase user - ${email}: ${err}`);
-        throw new HttpException(CREATE_USER_FIREBASE_ERROR, HttpStatus.BAD_REQUEST);
+        throw new HttpException(FIREBASE_ERRORS.CREATE_USER_FIREBASE_ERROR, HttpStatus.BAD_REQUEST);
       }
     }
   }

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -1,5 +1,6 @@
 import { ConsoleLogger } from '@nestjs/common';
 import Rollbar from 'rollbar';
+import { FIREBASE_ERRORS } from 'src/utils/errors';
 import { isProduction, rollbarEnv, rollbarToken } from '../utils/constants';
 
 export class Logger extends ConsoleLogger {
@@ -36,6 +37,7 @@ export class Logger extends ConsoleLogger {
         accessToken: rollbarToken,
         captureUncaught: true,
         captureUnhandledRejections: true,
+        ignoredMessages: [...Object.values(FIREBASE_ERRORS)],
       });
     }
   }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -9,11 +9,12 @@ import { Logger } from 'src/logger/logger';
 import { SubscriptionUserService } from 'src/subscription-user/subscription-user.service';
 import { TherapySessionService } from 'src/therapy-session/therapy-session.service';
 import { SIGNUP_TYPE } from 'src/utils/constants';
+import { FIREBASE_ERRORS } from 'src/utils/errors';
 import {
   createServiceUserProfiles,
   updateServiceUserProfilesUser,
 } from 'src/utils/serviceUserProfiles';
-import { And, ILike, Raw, Repository, IsNull, Not } from 'typeorm';
+import { And, ILike, IsNull, Not, Raw, Repository } from 'typeorm';
 import { deleteCypressCrispProfiles } from '../api/crisp/crisp-api';
 import { AuthService } from '../auth/auth.service';
 import { PartnerAccessService, basePartnerAccess } from '../partner-access/partner-access.service';
@@ -98,7 +99,9 @@ export class UserService {
       });
       return userDto;
     } catch (error) {
-      this.logger.error(`Create user: Error creating user ${email}: ${error}`);
+      if (!Object.values(FIREBASE_ERRORS).includes(error)) {
+        this.logger.error(`Create user: Error creating user ${email}: ${error}`);
+      }
       throw error;
     }
   }
@@ -291,9 +294,10 @@ export class UserService {
         ...(filters.partnerAdmin && {
           partnerAdmin: {
             ...(filters.partnerAdmin && {
-              id: filters.partnerAdmin.partnerAdminId === 'IS NOT NULL'
-                ? Not(IsNull())
-                : filters.partnerAdmin.partnerAdminId
+              id:
+                filters.partnerAdmin.partnerAdminId === 'IS NOT NULL'
+                  ? Not(IsNull())
+                  : filters.partnerAdmin.partnerAdminId,
             }),
           },
         }),

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,4 +1,9 @@
-export const CREATE_USER_FIREBASE_ERROR = 'CREATE_USER_FIREBASE_ERROR';
-export const CREATE_USER_INVALID_EMAIL = 'CREATE_USER_INVALID_EMAIL';
-export const CREATE_USER_WEAK_PASSWORD = 'CREATE_USER_WEAK_PASSWORD';
-export const CREATE_USER_ALREADY_EXISTS = 'CREATE_USER_ALREADY_EXISTS';
+// Includes known/expected firebase errors from user inputs
+// These errors are returned to the user and display appropriate error messages
+// However these errors are ignored from rollbar and error logging
+export enum FIREBASE_ERRORS {
+  CREATE_USER_FIREBASE_ERROR = 'CREATE_USER_FIREBASE_ERROR',
+  CREATE_USER_INVALID_EMAIL = 'CREATE_USER_INVALID_EMAIL',
+  CREATE_USER_WEAK_PASSWORD = 'CREATE_USER_WEAK_PASSWORD',
+  CREATE_USER_ALREADY_EXISTS = 'CREATE_USER_ALREADY_EXISTS',
+}


### PR DESCRIPTION
### What changes did you make?
Added functionality to ignore common/expected errors from firebase, when creating a user.
The error is still thrown to the user, however we no longer log these specified error messages as an error in our logging or error reporting (rollbar)

```
export enum FIREBASE_ERRORS {
  CREATE_USER_FIREBASE_ERROR = 'CREATE_USER_FIREBASE_ERROR',
  CREATE_USER_INVALID_EMAIL = 'CREATE_USER_INVALID_EMAIL',
  CREATE_USER_WEAK_PASSWORD = 'CREATE_USER_WEAK_PASSWORD',
  CREATE_USER_ALREADY_EXISTS = 'CREATE_USER_ALREADY_EXISTS',
}
```

### Why did you make the changes?
Many errors are being thrown to Rollbar related to basic user actions (too short password, account exists)