### PR TITLE
fix: storyblok missing env var type

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -118,7 +118,8 @@ export const crispWebsiteId = getEnv(process.env.CRISP_WEBSITE_ID, 'CRISP_WEBSIT
 
 export const slackWebhookUrl = getEnv(process.env.SLACK_WEBHOOK_URL, 'SLACK_WEBHOOK_URL');
 
-export const storyblokToken = getEnv(process.env.STORYBLOK_PUBLIC_TOKEN, 'STORYBLOK_PUBLIC_TOKEN');
+export const storyblokToken =
+  getEnv(process.env.STORYBLOK_PUBLIC_TOKEN, 'STORYBLOK_PUBLIC_TOKEN') || '';
 
 export const storyblokWebhookSecret = getEnv(
   process.env.STORYBLOK_WEBHOOK_SECRET,


### PR DESCRIPTION
### What changes did you make?
Ensure the `STORYBLOK_PUBLIC_TOKEN` env var is always a string

### Why did you make the changes?
Tests were failing due to `createHmac` key type being undefined