### PR TITLE
Fix mailchimp profile new therapy

### DIFF
--- a/src/webhooks/webhooks.service.ts
+++ b/src/webhooks/webhooks.service.ts
@@ -243,7 +243,8 @@ export class WebhooksService {
       await this.partnerAccessRepository.save(partnerAccess);
       const therapySession = await this.therapySessionRepository.save(serializedTherapySession);
 
-      updateServiceUserProfilesTherapy([...partnerAccesses, partnerAccess], user.email);
+      partnerAccess.therapySession.push(therapySession);
+      updateServiceUserProfilesTherapy(partnerAccesses, user.email);
 
       return therapySession;
     } catch (err) {


### PR DESCRIPTION
### What changes did you make?
Fixed the `newPartnerAccessTherapy` function to make sure that new therapy bookings are being updated in mailchimp correctly 

### Why did you make the changes?
Mailchimp profile was not being updated for first therapy bookings, due to incorrect passing of objects to `updateServiceUserProfilesTherapy`