### PR TITLE
Fix user lastActiveAt migration

### DIFF
--- a/src/migrations/1718300621138-bloom-backend.ts
+++ b/src/migrations/1718300621138-bloom-backend.ts
@@ -1,16 +1,13 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class BloomBackend1718300621138 implements MigrationInterface {
-    name = 'BloomBackend1718300621138'
+  name = 'BloomBackend1718300621138';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "lastActiveAt"`);
-        await queryRunner.query(`ALTER TABLE "user" ADD "lastActiveAt" TIMESTAMP WITH TIME ZONE`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" ADD "lastActiveAt" TIMESTAMP WITH TIME ZONE`);
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "lastActiveAt"`);
-        await queryRunner.query(`ALTER TABLE "user" ADD "lastActiveAt" date`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "lastActiveAt"`);
+  }
 }


### PR DESCRIPTION
### What changes did you make?
Fixed migration commands for new user `lastActiveAt` field. Auto migrations added incorrect commands 

### Why did you make the changes?
Migration failed due to dropping non existent field