### PR TITLE
fix: encrypt staging database transactions

### DIFF
--- a/src/typeorm.config.ts
+++ b/src/typeorm.config.ts
@@ -51,6 +51,8 @@ config();
 const configService = new ConfigService();
 
 const isProduction = configService.get('NODE_ENV') === 'production';
+const isStaging = configService.get('NODE_ENV') === 'staging';
+
 const { host, port, user, password, database } = PostgressConnectionStringParser.parse(
   configService.get('DATABASE_URL'),
 );
@@ -114,9 +116,9 @@ export const dataSourceOptions = {
     BloomBackend1718728423454,
   ],
   subscribers: [],
-  ssl: isProduction,
+  ssl: isProduction || isStaging,
   extra: {
-    ssl: isProduction ? { rejectUnauthorized: false } : null,
+    ssl: isProduction || isStaging ? { rejectUnauthorized: false } : null,
   },
 };
 


### PR DESCRIPTION
### Issue link / number:
N/A

### What changes did you make?
Backend staging database crashed because database transactions were not encrypted

### Why did you make the changes?
Staging Backend was crashing