### PR TITLE
Fix update user id ref

### DIFF
--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -45,7 +45,7 @@ export class UserController {
   @Get('/me')
   @UseGuards(FirebaseAuthGuard)
   async getUserByFirebaseId(@Req() req: Request): Promise<GetUserDto> {
-    const user = req['user'];
+    const user = req['userEntity'];
     this.userService.updateUser({ lastActiveAt: new Date() }, user.id);
     return user;
   }


### PR DESCRIPTION
### What changes did you make?
Fixes use of `user.id` in GET `user/me`
The `user.id` was invalid as userDto type would require `user.user.id`. Updated `req['user'];` to `req['userEntity'];` where `user.id` will work as expected

### Why did you make the changes?
The incorrect id ref was causing a different user to be loaded in `updateUser` See example log below where one userId is used in the GET, and a different userId is updated

```
bloom-backend   | [Nest] 39  - 07/03/2024, 12:09:13 PM     LOG [Interceptor] Completed GET "/api/v1/user/me" (IP address: ::ffff:192.168.65.1, requestUserId: 7e44cadc-a02f-435d-8667-e129a3433f46) in 2ms

bloom-backend   | [Nest] 39  - 07/03/2024, 12:09:13 PM     LOG [UserService] Object:
bloom-backend   | {
bloom-backend   |   "event": "USER_UPDATED",
bloom-backend   |   "userId": "ac39ff8f-4f40-4167-a6bb-0cf2093ba5f0",
bloom-backend   |   "fields": [
bloom-backend   |     "lastActiveAt"
bloom-backend   |   ]
bloom-backend   | }

```