### PR TITLE
Fix user me return object

### DIFF
--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -45,9 +45,9 @@ export class UserController {
   @Get('/me')
   @UseGuards(FirebaseAuthGuard)
   async getUserByFirebaseId(@Req() req: Request): Promise<GetUserDto> {
-    const user = req['userEntity'];
-    this.userService.updateUser({ lastActiveAt: new Date() }, user.id);
-    return user;
+    const user = req['user'];
+    this.userService.updateUser({ lastActiveAt: new Date() }, user.user.id);
+    return user as GetUserDto;
   }
 
   /**


### PR DESCRIPTION
### What changes did you make?
Fix return object for GET /user/me from userEntity type to GetUserDto type

### Why did you make the changes?
This was recently broken in #505 where the return object was changed to `userEntity` by mistake, whilst trying to fix the `user.id` reference added in #502. The incorrect return type added in #505 was causing the frontend to crash on 3rd/4th July - fixed by rolling back and now this commit 