### PR TITLE
fix: webhook signature for storyblok

### DIFF
--- a/src/webhooks/webhooks.controller.spec.ts
+++ b/src/webhooks/webhooks.controller.spec.ts
@@ -27,7 +27,7 @@ const generateMockHeaders = (body) => {
 
 const createRequestObject = (body) => {
   return {
-    rawBody: JSON.stringify(body),
+    rawBody: '' + body,
     setEncoding: () => {},
     encoding: 'utf8',
   };

--- a/src/webhooks/webhooks.controller.ts
+++ b/src/webhooks/webhooks.controller.ts
@@ -54,8 +54,6 @@ export class WebhooksController {
       this.logger.error(error);
       throw new HttpException(error, HttpStatus.UNAUTHORIZED);
     }
-
-    req.rawBody = '' + data;
     req.setEncoding('utf8');
 
     const bodyHmac = createHmac('sha1', storyblokWebhookSecret).update(req.rawBody).digest('hex');


### PR DESCRIPTION
### Issue link / number:
N/A

### What changes did you make?
Updated how we handle the webhook signature as there was a signature mismatch

### Why did you make the changes?

Get storyblok webhooks to start passing

### Did you run tests?

Yes
