### PR TITLE
Fix seed database script

### DIFF
--- a/seed-local-db.sh
+++ b/seed-local-db.sh
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
 
-#Create Time Stamp
-DATE=`date "+%Y%m%d"`
-
-TIMESTAMP=`date "+%Y%m%d-%H%M%S"`
-
-set -e
-
 #Backup Remote database
-curl `heroku pg:backups public-url --app bloom-backend-staging` > bloom_$TIMESTAMP.dump
+heroku pg:backups:capture --app bloom-backend-staging
+heroku pg:backups:download --app bloom-backend-staging
 
 #Load backup into local database
-docker exec -i bloom-local-db pg_restore -U postgres -d bloom < bloom_$TIMESTAMP.dump
+docker exec -i bloom-local-db pg_restore -U postgres -d bloom < latest.dump
+
+rm latest.dump


### PR DESCRIPTION
### What changes did you make and why did you make them?
Fixed `seed-local-db.sh` script as this was throwing an error since postgres updated to v16. 
The issue was around the capture/download commands which have now been updated.

One change here is you now can't name the downloaded file, so this is defaulting to `latest.dump` instead of a timestamped filename. This issue is solved by deleting the dump file after it's been restored.

