### PR TITLE
Add crisp origin report

### DIFF
--- a/src/crisp/crisp.controller.ts
+++ b/src/crisp/crisp.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { SuperAdminAuthGuard } from 'src/partner-admin/super-admin-auth.guard';
+import { CrispService } from './crisp.service';
+
+@ApiTags('Crisp')
+@Controller('crisp')
+export class CrispController {
+  constructor(private readonly crispService: CrispService) {}
+
+  @Get('/analytics-message-origin')
+  @UseGuards(SuperAdminAuthGuard)
+  async getCrispMessageOriginAnalytics() {
+    return this.crispService.getCrispMessageOriginAnalytics();
+  }
+}

--- a/src/crisp/crisp.module.ts
+++ b/src/crisp/crisp.module.ts
@@ -3,10 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { EventLogEntity } from 'src/entities/event-log.entity';
 import { UserEntity } from 'src/entities/user.entity';
 import { EventLoggerService } from 'src/event-logger/event-logger.service';
+import { CrispController } from './crisp.controller';
 import { CrispService } from './crisp.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([EventLogEntity, UserEntity])],
   providers: [CrispService, EventLoggerService],
+  controllers: [CrispController],
 })
 export class CrispModule {}

--- a/src/event-logger/event-logger.service.ts
+++ b/src/event-logger/event-logger.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { EventLogEntity } from 'src/entities/event-log.entity';
 import { UserEntity } from 'src/entities/user.entity';
 import { Repository } from 'typeorm';
-import { ICreateEventLog } from './event-logger.interface';
+import { EVENT_NAME, ICreateEventLog } from './event-logger.interface';
 
 const logger = new Logger('EventLogger');
 
@@ -18,6 +18,13 @@ export class EventLoggerService {
 
   async getEventLog(id: string): Promise<EventLogEntity> {
     return await this.eventLoggerRepository.findOneBy({ id });
+  }
+
+  async getMessageSentEventLogs(): Promise<EventLogEntity[]> {
+    return await this.eventLoggerRepository.find({
+      where: { event: EVENT_NAME.CHAT_MESSAGE_SENT },
+      relations: { user: true },
+    });
   }
 
   async createEventLog({ email, userId, event, date }: ICreateEventLog) {


### PR DESCRIPTION
### Resolves #673 

### What changes did you make and why did you make them?
Added route/function to get all crisp messages and report how many were sent via email vs via chat widget. This will be used to validate whether crisp emails are used by users.

