### PR TITLE
Split crisp origin analytics routes

### DIFF
--- a/src/crisp/crisp.controller.ts
+++ b/src/crisp/crisp.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { SuperAdminAuthGuard } from 'src/partner-admin/super-admin-auth.guard';
 import { CrispService } from './crisp.service';
@@ -8,9 +8,15 @@ import { CrispService } from './crisp.service';
 export class CrispController {
   constructor(private readonly crispService: CrispService) {}
 
-  @Get('/analytics-message-origin')
+  @Get('/conversations')
   @UseGuards(SuperAdminAuthGuard)
-  async getCrispMessageOriginAnalytics() {
-    return this.crispService.getCrispMessageOriginAnalytics();
+  async getAllConversationSessionIds() {
+    return this.crispService.getAllConversationSessionIds();
+  }
+
+  @Post('/analytics-message-origin')
+  @UseGuards(SuperAdminAuthGuard)
+  async getCrispMessageOriginAnalytics(@Body() sessionIds: string[]) {
+    return this.crispService.getCrispMessageOriginAnalytics(sessionIds);
   }
 }


### PR DESCRIPTION
### Resolves #691 

### What changes did you make and why did you make them?
Following #691 splits the crisp report into two requests to prevent timeout