### PR TITLE
Fix crisp people data error

### DIFF
--- a/src/api/mailchimp/mailchimp-api.ts
+++ b/src/api/mailchimp/mailchimp-api.ts
@@ -32,7 +32,7 @@ export const createMailchimpProfile = async (
   try {
     return await mailchimp.lists.addListMember(mailchimpAudienceId, profileData);
   } catch (error) {
-    throw new Error(`Create mailchimp profile API call failed: ${error}`);
+    throw new Error(`Create mailchimp profile API call failed: ${JSON.stringify(error)}`);
   }
 };
 

--- a/src/crisp/crisp.service.ts
+++ b/src/crisp/crisp.service.ts
@@ -101,11 +101,9 @@ export class CrispService {
     email: string,
   ): Promise<CrispProfileDataResponse> {
     try {
-      const crispPeopleData = CrispClient.website.updatePeopleData(
-        crispWebsiteId,
-        email,
-        peopleData,
-      );
+      const crispPeopleData = CrispClient.website.updatePeopleData(crispWebsiteId, email, {
+        data: peopleData,
+      });
       return crispPeopleData;
     } catch (error) {
       throw new Error(`Update crisp profile API call failed: ${error}`);


### PR DESCRIPTION
### What changes did you make and why did you make them?
Fixes issue with service profiles not being created/updated correctly due to invalid schema bug.

The `updatePeopleData` for crisp requires the profile data to be wrapped in `{data:...}` which was causing an error and preventing both crisp and mailchimp profiles from being created between 29/10/24- 6/1/25

