### PR TITLE
mailchimp bulk upload route

### DIFF
--- a/src/service-user-profiles/service-user-profiles.service.ts
+++ b/src/service-user-profiles/service-user-profiles.service.ts
@@ -238,8 +238,8 @@ export class ServiceUserProfilesService {
   // UPDATE THE FILTERS to the current requirements
   public async bulkUploadMailchimpProfiles() {
     try {
-      const filterStartDate = '2023-01-01'; // UPDATE
-      const filterEndDate = '2024-01-01'; // UPDATE
+      const filterStartDate = '2024-10-29'; // UPDATE
+      const filterEndDate = '2025-01-06'; // UPDATE
       const users = await this.userRepository.find({
         where: {
           // UPDATE TO ANY FILTERS

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -14,6 +14,7 @@ import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiTags } from '@nestjs
 import { Request } from 'express';
 import { UserEntity } from 'src/entities/user.entity';
 import { SuperAdminAuthGuard } from 'src/partner-admin/super-admin-auth.guard';
+import { ServiceUserProfilesService } from 'src/service-user-profiles/service-user-profiles.service';
 import { formatUserObject } from 'src/utils/serialize';
 import { FirebaseAuthGuard } from '../firebase/firebase-auth.guard';
 import { ControllerDecorator } from '../utils/controller.decorator';
@@ -27,7 +28,10 @@ import { UserService } from './user.service';
 @ControllerDecorator()
 @Controller('/v1/user')
 export class UserController {
-  constructor(private readonly userService: UserService) {}
+  constructor(
+    private readonly userService: UserService,
+    private readonly serviceUserProfilesService: ServiceUserProfilesService,
+  ) {}
 
   @Post()
   @ApiOperation({
@@ -104,5 +108,13 @@ export class UserController {
       : { include: [], fields: [], limit: undefined };
     const users = await this.userService.getUsers(userQuery, include || [], fields, limit);
     return users.map((u) => formatUserObject(u));
+  }
+
+  @ApiBearerAuth()
+  @Get('/bulk-upload-mailchimp-profiles')
+  @UseGuards(SuperAdminAuthGuard)
+  async bulkUploadMailchimpProfiles() {
+    await this.serviceUserProfilesService.bulkUploadMailchimpProfiles();
+    return 'ok';
   }
 }


### PR DESCRIPTION
### What changes did you make and why did you make them?
Adds route for bulk mailchimp upload. Route was previously removed for safety as this is an occasional route where the params are static in the code, but now the route is required again to upload missed users.