### PR TITLE
fix: name of courses in database

### DIFF
--- a/src/webhooks/webhooks.service.spec.ts
+++ b/src/webhooks/webhooks.service.spec.ts
@@ -429,7 +429,7 @@ describe('WebhooksService', () => {
         storyblokUuid: mockCourseStoryblokResult.data.story.uuid,
         status: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
         slug: mockCourseStoryblokResult.data.story.full_slug,
-        name: mockCourseStoryblokResult.data.story.name,
+        name: mockCourseStoryblokResult.data.story.content.name,
       };
 
       const course = (await service.handleStoryUpdated(body)) as CourseEntity;
@@ -442,7 +442,7 @@ describe('WebhooksService', () => {
       expect(courseSaveRepoSpy).toHaveBeenCalledWith(expectedResponse);
 
       expect(mockedServiceUserProfilesService.createMailchimpCourseMergeField).toHaveBeenCalledWith(
-        mockCourseStoryblokResult.data.story.name,
+        mockCourseStoryblokResult.data.story.content.name,
       );
       courseFindOneRepoSpy.mockClear();
       courseSaveRepoSpy.mockClear();
@@ -536,7 +536,7 @@ describe('WebhooksService', () => {
       const updatedMockResourceStoryblokResult = { ...mockResourceStoryblokResult };
       const newName = 'New resource name';
       const newSlug = 'resources/shorts/new-resource-name';
-      updatedMockResourceStoryblokResult.data.story.name = newName;
+      updatedMockResourceStoryblokResult.data.story.content.name = newName;
       updatedMockResourceStoryblokResult.data.story.full_slug = newSlug;
 
       // Mock StoryblokClient to return a resource story

--- a/src/webhooks/webhooks.service.ts
+++ b/src/webhooks/webhooks.service.ts
@@ -270,7 +270,7 @@ export class WebhooksService {
     const storyPageComponent = storyData.content.component as STORYBLOK_PAGE_COMPONENTS;
 
     const updatedStoryData = {
-      name: storyData.name,
+      name: storyData.content.name,
       slug: storyData.full_slug,
       status: status,
     }; // fields to update on existing and new stories


### PR DESCRIPTION
### Resolves #enter-issue-number
N/A

### What changes did you make and why did you make them?
Our courses are all named "overview" because we are pulling the wrong name from storyblok

