### PR TITLE
Fix azure CI migration - use yarn

### DIFF
--- a/.github/workflows/develop_bloom-staging.yml
+++ b/.github/workflows/develop_bloom-staging.yml
@@ -4,7 +4,7 @@
 name: Build and deploy Node.js app to Azure Web App - bloom-staging
 
 on:
-  push:
+  pull_request:
     branches:
       - develop
   workflow_dispatch:
@@ -20,17 +20,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Node.js version
-        uses: actions/setup-node@v3
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Use NodeJs
+        uses: actions/setup-node@v4
         with:
           node-version: '22.x'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
-      - name: npm install, build, and test
+      - name: yarn build, and test
         run: |
-          npm install
-          npm run build --if-present
-          npm run test --if-present
+          yarn build --if-present
+          yarn test --if-present
 
       - name: Zip artifact for deployment
         run: zip release.zip ./* -r
@@ -45,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     environment:
-      name: 'Production'
+      name: 'Staging' # Change the environment name to Staging
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
     permissions:
       id-token: write #This is required for requesting the JWT
@@ -72,8 +83,8 @@ jobs:
         uses: azure/webapps-deploy@v3
         with:
           app-name: 'bloom-staging'
-          slot-name: 'Production'
+          slot-name: 'Staging' # Change the slot name to Staging
           package: .
 
       - name: Run migrations
-        run: npm run typeorm migration:run -- -d ./src/typeorm.config.ts
+        run: yarn migration:run


### PR DESCRIPTION
### What changes did you make and why did you make them?
Updates the azure deploy CI action to use yarn instead of npm. There was an issue running the migration script in npm and we use yarn lockfiles.