### PR TITLE
Cancel therapy function

### DIFF
--- a/src/therapy-session/therapy-session.service.spec.ts
+++ b/src/therapy-session/therapy-session.service.spec.ts
@@ -5,6 +5,7 @@ import axios from 'axios';
 import { SlackMessageClient } from 'src/api/slack/slack-api';
 import { PartnerAccessEntity } from 'src/entities/partner-access.entity';
 import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
+import { ServiceUserProfilesService } from 'src/service-user-profiles/service-user-profiles.service';
 import { SIMPLYBOOK_ACTION_ENUM } from 'src/utils/constants';
 import {
   mockSimplybookBodyBase,
@@ -31,6 +32,7 @@ describe('TherapySessionService', () => {
   let service: TherapySessionService;
   let mockedTherapySessionRepository: DeepMocked<Repository<TherapySessionEntity>>;
   let mockedPartnerAccessRepository: DeepMocked<Repository<PartnerAccessEntity>>;
+  let mockServiceUserProfilesService: DeepMocked<ServiceUserProfilesService>;
   const mockedSlackMessageClient = createMock<SlackMessageClient>(mockSlackMessageClientMethods);
 
   beforeEach(async () => {
@@ -43,6 +45,8 @@ describe('TherapySessionService', () => {
       mockPartnerAccessRepositoryMethods,
     );
 
+    mockServiceUserProfilesService = createMock<ServiceUserProfilesService>();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TherapySessionService,
@@ -54,6 +58,7 @@ describe('TherapySessionService', () => {
           provide: getRepositoryToken(PartnerAccessEntity),
           useValue: mockedPartnerAccessRepository,
         },
+        { provide: ServiceUserProfilesService, useValue: mockServiceUserProfilesService },
         {
           provide: SlackMessageClient,
           useValue: mockedSlackMessageClient,

--- a/src/therapy-session/therapy-session.service.spec.ts
+++ b/src/therapy-session/therapy-session.service.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import axios from 'axios';
 import { SlackMessageClient } from 'src/api/slack/slack-api';
+import { PartnerAccessEntity } from 'src/entities/partner-access.entity';
 import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
 import { SIMPLYBOOK_ACTION_ENUM } from 'src/utils/constants';
 import {
@@ -11,6 +12,7 @@ import {
   mockUserEntity,
 } from 'test/utils/mockData';
 import {
+  mockPartnerAccessRepositoryMethods,
   mockSlackMessageClientMethods,
   mockTherapySessionRepositoryMethods,
 } from 'test/utils/mockedServices';
@@ -28,6 +30,7 @@ const simplyBookAuthResponse = {
 describe('TherapySessionService', () => {
   let service: TherapySessionService;
   let mockedTherapySessionRepository: DeepMocked<Repository<TherapySessionEntity>>;
+  let mockedPartnerAccessRepository: DeepMocked<Repository<PartnerAccessEntity>>;
   const mockedSlackMessageClient = createMock<SlackMessageClient>(mockSlackMessageClientMethods);
 
   beforeEach(async () => {
@@ -36,6 +39,9 @@ describe('TherapySessionService', () => {
     mockedTherapySessionRepository = createMock<Repository<TherapySessionEntity>>(
       mockTherapySessionRepositoryMethods,
     );
+    mockedPartnerAccessRepository = createMock<Repository<PartnerAccessEntity>>(
+      mockPartnerAccessRepositoryMethods,
+    );
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -43,6 +49,10 @@ describe('TherapySessionService', () => {
         {
           provide: getRepositoryToken(TherapySessionEntity),
           useValue: mockedTherapySessionRepository,
+        },
+        {
+          provide: getRepositoryToken(PartnerAccessEntity),
+          useValue: mockedPartnerAccessRepository,
         },
         {
           provide: SlackMessageClient,

--- a/src/therapy-session/therapy-session.service.ts
+++ b/src/therapy-session/therapy-session.service.ts
@@ -15,7 +15,8 @@ export class TherapySessionService {
   constructor(
     @InjectRepository(TherapySessionEntity)
     private therapySessionRepository: Repository<TherapySessionEntity>,
-    private readonly partnerAccessRepository: Repository<PartnerAccessEntity>,
+    @InjectRepository(PartnerAccessEntity)
+    private partnerAccessRepository: Repository<PartnerAccessEntity>,
     private readonly serviceUserProfilesService: ServiceUserProfilesService,
     private slackMessageClient: SlackMessageClient,
   ) {}

--- a/src/therapy-session/therapy-session.service.ts
+++ b/src/therapy-session/therapy-session.service.ts
@@ -31,8 +31,6 @@ export class TherapySessionService {
       });
       await cancelBooking(therapySession.bookingCode);
 
-      therapySession.cancelledAt = new Date();
-
       const updatedTherapySession = await this.therapySessionRepository.save({
         ...therapySession,
         cancelledAt: new Date(),


### PR DESCRIPTION
### What changes did you make and why did you make them?
Improves the cancel therapy route, which will now be used in the new therapy page.

For now we are keeping the duplicate cancel logic in `webhooks.service.ts` as users can still cancel the booking via simplybook emails/the widget, which triggers a zapier event to cancel the session in our db too.
