### PR TITLE
Add therapy session booking id field

### DIFF
--- a/src/api/simplybook/simplybook-api.ts
+++ b/src/api/simplybook/simplybook-api.ts
@@ -63,6 +63,35 @@ const queryBookingsForDate: (date: Date) => Promise<BookingResponse[]> = async (
   }
 };
 
+export const getBookingId: (bookingCode: string) => Promise<number> = async (
+  bookingCode: string,
+) => {
+  const token = await getAuthToken();
+
+  try {
+    const bookingsResponse = await axios.get(
+      `${SIMPLYBOOK_API_BASE_URL}/bookings?filter[search]=${bookingCode}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Company-Login': simplybookCompanyName,
+          'X-Token': `${token}`,
+        },
+      },
+    );
+
+    if (!bookingsResponse || !bookingsResponse.data) {
+      throw new Error(`No data returned from Simplybook API. Response: ${bookingsResponse}`);
+    }
+    return bookingsResponse.data.id;
+  } catch (error) {
+    handleError(
+      `Failed to retrieve booking information for code ${bookingCode} from Simplybook.`,
+      error,
+    );
+  }
+};
+
 export const getBookingsForDate: (date: Date) => Promise<BookingInfo[]> = async (date: Date) => {
   try {
     const bookings: BookingResponse[] = await queryBookingsForDate(date);
@@ -80,7 +109,7 @@ export const getBookingsForDate: (date: Date) => Promise<BookingInfo[]> = async 
   }
 };
 
-export const cancelBooking: (id: string) => Promise<BookingResponse[]> = async (id: string) => {
+export const cancelBooking: (id: number) => Promise<BookingResponse[]> = async (id: number) => {
   const token = await getAuthToken();
 
   try {

--- a/src/entities/therapy-session.entity.ts
+++ b/src/entities/therapy-session.entity.ts
@@ -19,6 +19,9 @@ export class TherapySessionEntity extends BaseBloomEntity {
   bookingCode: string;
 
   @Column({ nullable: true })
+  bookingId: number;
+
+  @Column({ nullable: true })
   clientTimezone: string;
 
   @Column()

--- a/src/migrations/1748540025892-bloom-backend.ts
+++ b/src/migrations/1748540025892-bloom-backend.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class BloomBackend1748540025892 implements MigrationInterface {
+    name = 'BloomBackend1748540025892'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "therapy_session" ADD "bookingId" integer`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "therapy_session" DROP COLUMN "bookingId"`);
+    }
+
+}

--- a/src/therapy-session/therapy-session.service.ts
+++ b/src/therapy-session/therapy-session.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { cancelBooking } from 'src/api/simplybook/simplybook-api';
+import { cancelBooking, getBookingId } from 'src/api/simplybook/simplybook-api';
 import { SlackMessageClient } from 'src/api/slack/slack-api';
 import { PartnerAccessEntity } from 'src/entities/partner-access.entity';
 import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
@@ -30,10 +30,17 @@ export class TherapySessionService {
           user: true,
         },
       });
-      await cancelBooking(therapySession.bookingCode);
+      let bookingId = therapySession.bookingId;
+
+      if (bookingId) {
+        bookingId = await getBookingId(therapySession.bookingCode);
+      }
+
+      await cancelBooking(bookingId);
 
       const updatedTherapySession = await this.therapySessionRepository.save({
         ...therapySession,
+        bookingId,
         cancelledAt: new Date(),
         action: SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING,
       });

--- a/src/typeorm.config.ts
+++ b/src/typeorm.config.ts
@@ -56,6 +56,7 @@ import { BloomBackend1733160378757 } from './migrations/1733160378757-bloom-back
 import { BloomBackend1733850090811 } from './migrations/1733850090811-bloom-backend';
 import { BloomBackend1743510885507 } from './migrations/1743510885507-bloom-backend';
 import { BloomBackend1744450013565 } from './migrations/1744450013565-bloom-backend';
+import { BloomBackend1748540025892 } from './migrations/1748540025892-bloom-backend';
 
 config();
 const configService = new ConfigService();
@@ -133,7 +134,8 @@ export const dataSourceOptions = {
     BloomBackend1733160378757,
     BloomBackend1733850090811,
     BloomBackend1743510885507,
-    BloomBackend1744450013565
+    BloomBackend1744450013565,
+    BloomBackend1748540025892,
   ],
   subscribers: [],
   ssl: isProduction || isStaging,

--- a/src/webhooks/webhooks.interface.ts
+++ b/src/webhooks/webhooks.interface.ts
@@ -3,6 +3,8 @@ import { SIMPLYBOOK_ACTION_ENUM } from 'src/utils/constants';
 export interface ITherapySession {
   id?: string;
   action?: SIMPLYBOOK_ACTION_ENUM;
+  bookingId: number;
+  bookingCode?: string;
   clientTimezone?: string;
   serviceName?: string;
   serviceProviderName?: string;


### PR DESCRIPTION
This PR adds a `bookingId` field to the `TherapySession` entity, as the `id` provided by simplybook, is required to perform api calls related to that simplybook booking. 

Now when a cancel session request is made, we attempt to get/set the `bookingId` of the `TherapySession` record, and use it to cancel the booking