### PR TITLE
refactor: storyblokId in webhook

### DIFF
--- a/src/course/course.interface.ts
+++ b/src/course/course.interface.ts
@@ -7,7 +7,7 @@ export interface ICourse {
   name?: string;
   slug?: string;
   status?: STORYBLOK_STORY_STATUS_ENUM;
-  storyblokId?: string;
+  storyblokUuid?: string;
 }
 export interface ICoursesWithSessions {
   id: string;

--- a/src/webhooks/webhooks.service.ts
+++ b/src/webhooks/webhooks.service.ts
@@ -353,11 +353,11 @@ export class WebhooksService {
   }
 
   // TODO once story_uuid is sent via the webhook we can change the arguements to story_uuid
-  async updateInactiveStoryStatus(story_id: number, status: STORYBLOK_STORY_STATUS_ENUM) {
+  async updateInactiveStoryStatus(storyblokUuid: string, status: STORYBLOK_STORY_STATUS_ENUM) {
     // Story is deleted so cant be fetched from storyblok to get story type
     // Try to find course with matching story_id first
     let course = await this.courseRepository.findOneBy({
-      storyblokId: story_id, // TODO change to storyblokUuid once available
+      storyblokUuid: storyblokUuid, // TODO change to storyblokUuid once available
     });
 
     if (course) {
@@ -367,7 +367,7 @@ export class WebhooksService {
     }
     // No course found, try finding session instead
     let session = await this.sessionRepository.findOneBy({
-      storyblokId: story_id, // TODO change to storyblokUuid once available
+      storyblokUuid: storyblokUuid, // TODO change to storyblokUuid once available
     });
 
     if (session) {
@@ -378,7 +378,7 @@ export class WebhooksService {
 
     // No session found, try finding resource instead
     let resource = await this.resourceRepository.findOneBy({
-      storyblokId: story_id, // TODO change to storyblokUuid once available
+      storyblokUuid: storyblokUuid, // TODO change to storyblokUuid once available
     });
 
     if (resource) {
@@ -395,14 +395,6 @@ export class WebhooksService {
     const story_id = data.story_id;
 
     this.logger.log(`Storyblok story ${status} request - ${story_id}`);
-
-    if (
-      status === STORYBLOK_STORY_STATUS_ENUM.UNPUBLISHED ||
-      status === STORYBLOK_STORY_STATUS_ENUM.DELETED
-    ) {
-      // Story can't be retrieved from storyblok so we just update the status of existing records
-      return this.updateInactiveStoryStatus(story_id, status);
-    }
 
     // Story was either published or moved
     // Retrieve the story data from storyblok before handling the update/create
@@ -425,6 +417,16 @@ export class WebhooksService {
       const error = `Storyblok webhook failed - error getting story from storyblok - ${err}`;
       this.logger.error(error);
       throw new HttpException(error, HttpStatus.NOT_FOUND);
+    }
+
+    const storyblokUuid = story?.uuid;
+
+    if (
+      status === STORYBLOK_STORY_STATUS_ENUM.UNPUBLISHED ||
+      status === STORYBLOK_STORY_STATUS_ENUM.DELETED
+    ) {
+      // Story can't be retrieved from storyblok so we just update the status of existing records
+      return this.updateInactiveStoryStatus(storyblokUuid, status);
     }
 
     // Create or update the resource/course/session record in our database


### PR DESCRIPTION

### What changes did you make and why did you make them?
This pull request updates the codebase to replace the usage of `storyblokId` with `storyblokUuid` for consistency and to align with the expected data structure from Storyblok webhooks. Additionally, it refactors the logic for handling Storyblok story statuses to ensure proper usage of the new `storyblokUuid` field.

### Transition from `storyblokId` to `storyblokUuid`:

* [`src/course/course.interface.ts`](diffhunk://#diff-8716bd6f69d6a99b85a8d884609ad795a8e84d756dd58b577af7c87e6c09c4b9L10-R10): Replaced `storyblokId` with `storyblokUuid` in the `ICourse` interface to reflect the updated field naming convention.
* [`src/webhooks/webhooks.service.ts`](diffhunk://#diff-6119372442e46efb00d4acfd2b5577be5b9e3b19d555f77ddded12d7eaea5bc7L356-R360): Updated the `updateInactiveStoryStatus` method and repository queries to use `storyblokUuid` instead of `storyblokId` for course, session, and resource lookups. [[1]](diffhunk://#diff-6119372442e46efb00d4acfd2b5577be5b9e3b19d555f77ddded12d7eaea5bc7L356-R360) [[2]](diffhunk://#diff-6119372442e46efb00d4acfd2b5577be5b9e3b19d555f77ddded12d7eaea5bc7L370-R370) [[3]](diffhunk://#diff-6119372442e46efb00d4acfd2b5577be5b9e3b19d555f77ddded12d7eaea5bc7L381-R381)

### Refactoring of Storyblok story status handling:

* [`src/webhooks/webhooks.service.ts`](diffhunk://#diff-6119372442e46efb00d4acfd2b5577be5b9e3b19d555f77ddded12d7eaea5bc7L399-L406): Removed the old logic for handling `UNPUBLISHED` and `DELETED` statuses directly using `story_id`. Instead, introduced a new flow that retrieves `storyblokUuid` from the Storyblok story data and uses it for updating inactive story statuses. [[1]](diffhunk://#diff-6119372442e46efb00d4acfd2b5577be5b9e3b19d555f77ddded12d7eaea5bc7L399-L406) [[2]](diffhunk://#diff-6119372442e46efb00d4acfd2b5577be5b9e3b19d555f77ddded12d7eaea5bc7R422-R431)




