### PR TITLE
refactor: replaced IUser with GetUserDto and UserEntity

### DIFF
--- a/src/user/dtos/get-user.dto.ts
+++ b/src/user/dtos/get-user.dto.ts
@@ -2,10 +2,10 @@ import { IResource } from 'src/resource/resource.interface';
 import { ITherapySession } from 'src/webhooks/webhooks.interface';
 import { IPartnerAccessWithPartner } from '../../partner-access/partner-access.interface';
 import { IPartnerAdminWithPartner } from '../../partner-admin/partner-admin.interface';
-import { IUser } from '../user.interface';
+import { UserProfileDto } from './user-profile.dto';
 
 export class GetUserDto {
-  user: IUser;
+  user: UserProfileDto;
   partnerAccesses?: IPartnerAccessWithPartner[];
   partnerAdmin?: IPartnerAdminWithPartner;
   resources?: IResource[];

--- a/src/user/dtos/user-profile.dto.ts
+++ b/src/user/dtos/user-profile.dto.ts
@@ -1,6 +1,6 @@
-import { EMAIL_REMINDERS_FREQUENCY } from '../utils/constants';
+import { EMAIL_REMINDERS_FREQUENCY } from '../../utils/constants';
 
-export interface IUser {
+export class UserProfileDto {
   id: string;
   createdAt: Date | string;
   updatedAt: Date | string;

--- a/src/webhooks/webhooks.service.ts
+++ b/src/webhooks/webhooks.service.ts
@@ -9,7 +9,6 @@ import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
 import { UserEntity } from 'src/entities/user.entity';
 import { ZapierSimplybookBodyDto } from 'src/partner-access/dtos/zapier-body.dto';
 import { ServiceUserProfilesService } from 'src/service-user-profiles/service-user-profiles.service';
-import { IUser } from 'src/user/user.interface';
 import { serializeZapierSimplyBookDtoToTherapySessionEntity } from 'src/utils/serialize';
 import StoryblokClient, { ISbStoryData } from 'storyblok-js-client';
 import { ILike, MoreThan, Repository } from 'typeorm';
@@ -138,7 +137,10 @@ export class WebhooksService {
     }
   }
 
-  private async getSimplyBookTherapyUser(userId: string, client_email: string): Promise<IUser> {
+  private async getSimplyBookTherapyUser(
+    userId: string,
+    client_email: string,
+  ): Promise<UserEntity> {
     if (!userId) {
       // No userId sent in the webhook - likely due to user clicking simplybook link from email instead of in-app widget
       // Try to find a user associated to this email
@@ -191,7 +193,7 @@ export class WebhooksService {
     }
   }
 
-  private async newPartnerAccessTherapy(user: IUser, simplyBookDto: ZapierSimplybookBodyDto) {
+  private async newPartnerAccessTherapy(user: UserEntity, simplyBookDto: ZapierSimplybookBodyDto) {
     const partnerAccesses = await this.partnerAccessRepository.find({
       where: {
         userId: user.id,


### PR DESCRIPTION
### Resolves #760 

### What changes did you make and why did you make them?

- Replaced usage of `IUser` with `UserEntity` in `webhooks.service.ts` for consistency with service-layer conventions.
- Created `UserProfileDto` to serve as a replacement for `IUser` in controller-layer DTOs.
- Replaced `IUser` with `UserProfileDto` in `get-user.dto.ts`.

### Did you run tests? Share screenshot of results:

<img width="339" alt="Screenshot 2025-06-19 at 10 36 08 AM" src="https://github.com/user-attachments/assets/26babf95-85b0-4bce-85d3-7403e9225b60" />



### How did you find us? (GitHub, Google search, social media, etc.):

GitHub


