### PR TITLE
Fix storyblok webhook - throw error missing env

### DIFF
--- a/.github/workflows/.ci.yml
+++ b/.github/workflows/.ci.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       SIMPLYBOOK_CREDENTIALS: '{"login": "login"}'
+      STORYBLOK_PUBLIC_TOKEN: ${{ secrets.STORYBLOK_PUBLIC_TOKEN }}
       STORYBLOK_WEBHOOK_SECRET: ${{ secrets.STORYBLOK_WEBHOOK_SECRET }}
     steps:
       - uses: actions/checkout@v4

--- a/src/webhooks/webhooks.service.ts
+++ b/src/webhooks/webhooks.service.ts
@@ -402,6 +402,12 @@ export class WebhooksService {
     // Retrieve the story data from storyblok before handling the update/create
     let story: ISbStoryData;
 
+    if (!storyblokToken) {
+      const error = `Storyblok webhook failed - missing storyblok token`;
+      this.logger.error(error);
+      throw new HttpException(error, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
     const Storyblok = new StoryblokClient({
       accessToken: storyblokToken,
       cache: {


### PR DESCRIPTION
### What changes did you make and why did you make them?
Thows error if storyblok token env var is missing