### PR TITLE
Remove storyblokId field

### DIFF
--- a/src/entities/course.entity.ts
+++ b/src/entities/course.entity.ts
@@ -25,12 +25,6 @@ export class CourseEntity extends BaseBloomEntity {
     unique: true,
     nullable: true,
   })
-  storyblokId: number;
-
-  @Column({
-    unique: true,
-    nullable: true,
-  })
   storyblokUuid: string;
 
   @OneToMany(() => SessionEntity, (sessionEntity) => sessionEntity.course, { cascade: true })

--- a/src/entities/resource.entity.ts
+++ b/src/entities/resource.entity.ts
@@ -29,12 +29,6 @@ export class ResourceEntity extends BaseBloomEntity {
     unique: true,
     nullable: true,
   })
-  storyblokId: number;
-
-  @Column({
-    unique: true,
-    nullable: true,
-  })
   storyblokUuid: string;
 
   @OneToMany(() => ResourceUserEntity, (resourceUserEntity) => resourceUserEntity.resource, {

--- a/src/entities/session.entity.ts
+++ b/src/entities/session.entity.ts
@@ -25,12 +25,6 @@ export class SessionEntity extends BaseBloomEntity {
     unique: true,
     nullable: true,
   })
-  storyblokId: number;
-
-  @Column({
-    unique: true,
-    nullable: true,
-  })
   storyblokUuid: string;
 
   @Column()

--- a/src/migrations/1756987770157-bloom-backend.ts
+++ b/src/migrations/1756987770157-bloom-backend.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class BloomBackend1756987770157 implements MigrationInterface {
+    name = 'BloomBackend1756987770157'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "session" DROP CONSTRAINT "UQ_ba3527651cbf779979fa629291c"`);
+        await queryRunner.query(`ALTER TABLE "session" DROP COLUMN "storyblokId"`);
+        await queryRunner.query(`ALTER TABLE "resource" DROP CONSTRAINT "UQ_1b4b84228b725114ccc955dcec7"`);
+        await queryRunner.query(`ALTER TABLE "resource" DROP COLUMN "storyblokId"`);
+        await queryRunner.query(`ALTER TABLE "course" DROP CONSTRAINT "UQ_5a0a12dbf4f0976cdcb1702509e"`);
+        await queryRunner.query(`ALTER TABLE "course" DROP COLUMN "storyblokId"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "course" ADD "storyblokId" integer`);
+        await queryRunner.query(`ALTER TABLE "course" ADD CONSTRAINT "UQ_5a0a12dbf4f0976cdcb1702509e" UNIQUE ("storyblokId")`);
+        await queryRunner.query(`ALTER TABLE "resource" ADD "storyblokId" integer`);
+        await queryRunner.query(`ALTER TABLE "resource" ADD CONSTRAINT "UQ_1b4b84228b725114ccc955dcec7" UNIQUE ("storyblokId")`);
+        await queryRunner.query(`ALTER TABLE "session" ADD "storyblokId" integer`);
+        await queryRunner.query(`ALTER TABLE "session" ADD CONSTRAINT "UQ_ba3527651cbf779979fa629291c" UNIQUE ("storyblokId")`);
+    }
+
+}

--- a/src/typeorm.config.ts
+++ b/src/typeorm.config.ts
@@ -57,6 +57,7 @@ import { BloomBackend1733850090811 } from './migrations/1733850090811-bloom-back
 import { BloomBackend1743510885507 } from './migrations/1743510885507-bloom-backend';
 import { BloomBackend1744450013565 } from './migrations/1744450013565-bloom-backend';
 import { BloomBackend1748540025892 } from './migrations/1748540025892-bloom-backend';
+import { BloomBackend1756987770157 } from './migrations/1756987770157-bloom-backend';
 
 config();
 const configService = new ConfigService();
@@ -136,6 +137,7 @@ export const dataSourceOptions = {
     BloomBackend1743510885507,
     BloomBackend1744450013565,
     BloomBackend1748540025892,
+    BloomBackend1756987770157,
   ],
   subscribers: [],
   ssl: isProduction || isStaging,

--- a/src/webhooks/dto/story.dto.ts
+++ b/src/webhooks/dto/story.dto.ts
@@ -13,12 +13,6 @@ export class StoryWebhookDto {
   @ApiProperty({ type: String })
   action: STORYBLOK_STORY_STATUS_ENUM;
 
-  @IsNumber()
-  @IsNotEmpty()
-  @IsDefined()
-  @ApiProperty({ type: Number })
-  story_id: number;
-
   @IsOptional()
   @IsNumber()
   space_id?: number;

--- a/src/webhooks/webhooks.service.spec.ts
+++ b/src/webhooks/webhooks.service.spec.ts
@@ -187,20 +187,18 @@ describe('WebhooksService', () => {
 
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
-        story_id: mockSession.storyblokId,
         story_uuid: mockSession.storyblokUuid,
         text: '',
       };
 
       return expect(service.handleStoryUpdated(body)).rejects.toThrow(
-        `Storyblok webhook failed - story not found in storyblok for story ID ${mockSession.storyblokId}`,
+        `Storyblok webhook failed - story not found in storyblok for story uuid ${mockSession.storyblokUuid}`,
       );
     });
 
     it('when action is deleted, story should be set as deleted in database', async () => {
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.DELETED,
-        story_id: mockSession.storyblokId,
         story_uuid: mockSession.storyblokUuid,
         text: '',
       };
@@ -213,7 +211,6 @@ describe('WebhooksService', () => {
     it('when action is unpublished, story should be set as unpublished in database', async () => {
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.UNPUBLISHED,
-        story_id: mockSession.storyblokId,
         story_uuid: mockSession.storyblokUuid,
         text: '',
       };
@@ -258,7 +255,6 @@ describe('WebhooksService', () => {
 
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
-        story_id: mockCourse.storyblokId,
         story_uuid: mockCourse.storyblokUuid,
         text: '',
       };
@@ -301,7 +297,6 @@ describe('WebhooksService', () => {
 
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
-        story_id: mockSession.storyblokId,
         story_uuid: mockSession.storyblokUuid,
         full_slug: mockSession.slug,
         text: '',
@@ -309,7 +304,6 @@ describe('WebhooksService', () => {
 
       const expectedResponse = {
         storyblokUuid: mockSession.storyblokUuid,
-        storyblokId: mockSession.storyblokId,
         status: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
         slug: mockSession.slug,
         name: mockSession.name,
@@ -356,7 +350,6 @@ describe('WebhooksService', () => {
 
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
-        story_id: mockSession.storyblokId,
         story_uuid: mockSession.storyblokUuid,
         full_slug: mockSession.slug,
         text: '',
@@ -364,7 +357,6 @@ describe('WebhooksService', () => {
 
       const expectedResponse = {
         storyblokUuid: mockSession.storyblokUuid,
-        storyblokId: mockSession.storyblokId,
         status: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
         slug: mockSession.slug,
         name: mockSession.name,
@@ -399,7 +391,6 @@ describe('WebhooksService', () => {
 
       const expectedResponse = {
         storyblokUuid: mockCourseStoryblokResult.data.story.uuid,
-        storyblokId: mockCourseStoryblokResult.data.story.id,
         status: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
         slug: mockCourseStoryblokResult.data.story.full_slug,
         name: mockCourseStoryblokResult.data.story.content.name,
@@ -424,7 +415,6 @@ describe('WebhooksService', () => {
     it('should handle unpublished action for a resource', async () => {
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.UNPUBLISHED,
-        story_id: mockResource.storyblokId,
         story_uuid: mockResource.storyblokUuid,
         text: '',
       };
@@ -437,7 +427,6 @@ describe('WebhooksService', () => {
     it('should handle published action for a resource', async () => {
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
-        story_id: mockResource.storyblokId,
         story_uuid: mockResource.storyblokUuid,
         text: '',
       };
@@ -450,7 +439,6 @@ describe('WebhooksService', () => {
     it('should handle deleted action for a resource', async () => {
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.DELETED,
-        story_id: mockResource.storyblokId,
         story_uuid: mockResource.storyblokUuid,
         text: '',
       };
@@ -478,7 +466,6 @@ describe('WebhooksService', () => {
 
       const expectedResponse = {
         storyblokUuid: mockResourceStoryblokResult.data.story.uuid,
-        storyblokId: mockResourceStoryblokResult.data.story.id,
         status: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
         slug: mockResourceStoryblokResult.data.story.full_slug,
         name: mockResourceStoryblokResult.data.story.name,

--- a/src/webhooks/webhooks.service.spec.ts
+++ b/src/webhooks/webhooks.service.spec.ts
@@ -187,19 +187,19 @@ describe('WebhooksService', () => {
 
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
-        story_uuid: mockSession.storyblokUuid,
+        full_slug: mockSession.slug,
         text: '',
       };
 
       return expect(service.handleStoryUpdated(body)).rejects.toThrow(
-        `Storyblok webhook failed - story not found in storyblok for story uuid ${mockSession.storyblokUuid}`,
+        `Storyblok webhook failed - story not found in storyblok for story ${mockSession.slug}`,
       );
     });
 
     it('when action is deleted, story should be set as deleted in database', async () => {
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.DELETED,
-        story_uuid: mockSession.storyblokUuid,
+        full_slug: mockSession.slug,
         text: '',
       };
 
@@ -211,7 +211,7 @@ describe('WebhooksService', () => {
     it('when action is unpublished, story should be set as unpublished in database', async () => {
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.UNPUBLISHED,
-        story_uuid: mockSession.storyblokUuid,
+        full_slug: mockSession.slug,
         text: '',
       };
 
@@ -255,7 +255,7 @@ describe('WebhooksService', () => {
 
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
-        story_uuid: mockCourse.storyblokUuid,
+        full_slug: mockCourse.slug,
         text: '',
       };
 
@@ -297,7 +297,6 @@ describe('WebhooksService', () => {
 
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
-        story_uuid: mockSession.storyblokUuid,
         full_slug: mockSession.slug,
         text: '',
       };
@@ -350,7 +349,6 @@ describe('WebhooksService', () => {
 
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
-        story_uuid: mockSession.storyblokUuid,
         full_slug: mockSession.slug,
         text: '',
       };
@@ -384,7 +382,6 @@ describe('WebhooksService', () => {
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
         story_id: mockCourseStoryblokResult.data.story.id,
-        story_uuid: mockCourseStoryblokResult.data.story.uuid,
         full_slug: mockCourseStoryblokResult.data.story.full_slug,
         text: '',
       };
@@ -415,7 +412,7 @@ describe('WebhooksService', () => {
     it('should handle unpublished action for a resource', async () => {
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.UNPUBLISHED,
-        story_uuid: mockResource.storyblokUuid,
+        full_slug: mockResource.slug,
         text: '',
       };
 
@@ -427,7 +424,7 @@ describe('WebhooksService', () => {
     it('should handle published action for a resource', async () => {
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
-        story_uuid: mockResource.storyblokUuid,
+        full_slug: mockResource.slug,
         text: '',
       };
 
@@ -439,7 +436,7 @@ describe('WebhooksService', () => {
     it('should handle deleted action for a resource', async () => {
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.DELETED,
-        story_uuid: mockResource.storyblokUuid,
+        full_slug: mockResource.slug,
         text: '',
       };
 
@@ -459,7 +456,6 @@ describe('WebhooksService', () => {
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
         story_id: mockResourceStoryblokResult.data.story.id,
-        story_uuid: mockResourceStoryblokResult.data.story.uuid,
         full_slug: mockResourceStoryblokResult.data.story.full_slug,
         text: '',
       };
@@ -501,7 +497,6 @@ describe('WebhooksService', () => {
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
         story_id: mockResourceStoryblokResult.data.story.id,
-        story_uuid: mockResourceStoryblokResult.data.story.uuid,
         full_slug: mockResourceStoryblokResult.data.story.full_slug,
         text: '',
       };
@@ -544,7 +539,6 @@ describe('WebhooksService', () => {
       const body = {
         action: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
         story_id: mockResourceStoryblokResult.data.story.id,
-        story_uuid: mockResourceStoryblokResult.data.story.uuid,
         full_slug: mockResourceStoryblokResult.data.story.full_slug,
         text: '',
       };

--- a/src/webhooks/webhooks.service.ts
+++ b/src/webhooks/webhooks.service.ts
@@ -277,7 +277,6 @@ export class WebhooksService {
     }; // fields to update on existing and new stories
 
     const newStoryData = {
-      storyblokId: storyData.id,
       storyblokUuid: storyData.uuid,
       ...updatedStoryData,
     }; // includes storyblok id and uuid for new stories only
@@ -395,9 +394,9 @@ export class WebhooksService {
   // Triggered by a webhook, this function handles updating our database records to sync with storyblok story data
   async handleStoryUpdated(data: StoryWebhookDto) {
     const status = data.action;
-    const story_id = data.story_id;
+    const story_slug = data.full_slug;
 
-    this.logger.log(`Storyblok story ${status} request - ${story_id}`);
+    this.logger.log(`Storyblok story ${status} request - ${story_slug}`);
 
     // Story was either published or moved
     // Retrieve the story data from storyblok before handling the update/create
@@ -411,7 +410,7 @@ export class WebhooksService {
 
     try {
       const response = await apiCall({
-        url: `https://api.storyblok.com/v2/cdn/stories/${story_id}?token=${storyblokToken}`,
+        url: `https://api.storyblok.com/v2/cdn/stories/${story_slug}?token=${storyblokToken}`,
         type: 'get',
       });
       if (response?.data?.story) {
@@ -419,7 +418,7 @@ export class WebhooksService {
       }
     } catch (err) {
       if (err.status === 404) {
-        const error = `Storyblok webhook failed - story not found in storyblok for story ID ${story_id}`;
+        const error = `Storyblok webhook failed - story not found in storyblok for story ${story_slug}`;
         this.logger.error(error);
         throw new HttpException(error, HttpStatus.NOT_FOUND);
       }
@@ -428,8 +427,8 @@ export class WebhooksService {
       throw new HttpException(error, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
-    if (!story || !story.uuid) {
-      const error = `Storyblok webhook failed - missing story or uuid in response for story ID ${story_id}`;
+    if (!story || !story.slug) {
+      const error = `Storyblok webhook failed - missing story in response for story ${story_slug}`;
       this.logger.error(error);
       throw new HttpException(error, HttpStatus.BAD_REQUEST);
     }

--- a/test/utils/mockData.ts
+++ b/test/utils/mockData.ts
@@ -109,7 +109,6 @@ export const mockCourse: CourseEntity = {
   coursePartner: [],
   courseUser: [],
   id: 'courseId1',
-  storyblokId: 123456,
   storyblokUuid: 'courseUuid1',
   slug: '/slug/slug',
   status: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
@@ -122,7 +121,6 @@ export const mockCourse: CourseEntity = {
 export const mockSession: SessionEntity = {
   sessionUser: [],
   id: 'sessionId1',
-  storyblokId: 123456,
   storyblokUuid: 'sessionStoryblokUuid1',
   slug: 'courses/creating-boundaries/what-are-boundaries',
   status: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
@@ -137,7 +135,6 @@ export const mockSession: SessionEntity = {
 export const mockResource: ResourceEntity = {
   resourceUser: [],
   id: 'resourceId1',
-  storyblokId: 123456,
   storyblokUuid: 'resourceUuid1',
   slug: 'resources/shorts/resource-name',
   status: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,
@@ -150,7 +147,6 @@ export const mockResource: ResourceEntity = {
 
 export const mockResource2: ResourceEntity = {
   id: 'resourceId2',
-  storyblokId: 98765,
   storyblokUuid: 'resourceUuid2',
   slug: 'resources/shorts/resource-name',
   status: STORYBLOK_STORY_STATUS_ENUM.PUBLISHED,


### PR DESCRIPTION
### Resolves #enter-issue-number
#782 #storyblokid

### What changes did you make and why did you make them?
Removes `storyblokid` field and all uses of the field, replacing with `full_slug` in its only usecase in webhooks. Webhooks currently do not send `uuid` which would've been a better solution.