### PR TITLE
Fix get user access for inactive partners

### DIFF
--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -132,10 +132,14 @@ export class UserService {
   }> {
     const queryResult = await this.userRepository
       .createQueryBuilder('user')
-      .leftJoinAndSelect('user.partnerAccess', 'partnerAccess')
+      .leftJoinAndSelect('user.partnerAccess', 'partnerAccess', 'partnerAccess.active = :active', {
+        isActive: true,
+      })
       .leftJoinAndSelect('user.partnerAdmin', 'partnerAdmin')
+      .leftJoinAndSelect('user.partnerAdmin', 'partnerAdmin', 'partnerAdmin.active = :active', {
+        isActive: true,
+      })
       .leftJoinAndSelect('partnerAccess.partner', 'partner')
-      .leftJoinAndSelect('partnerAccess.partner', 'partnerAccessPartner')
       .leftJoinAndSelect('partnerAdmin.partner', 'partnerAdminPartner')
       .leftJoinAndSelect('user.resourceUser', 'resourceUser')
       .leftJoinAndSelect('resourceUser.resource', 'resource')


### PR DESCRIPTION
### What changes did you make and why did you make them?
Ensures that only active `partnerAccess` and `partnerAdmin` records are returned in the core getUserProfile functionality