### PR TITLE
Fix session feedback sessionId + resource feedback guard

### DIFF
--- a/src/entities/session-feedback.entity.ts
+++ b/src/entities/session-feedback.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { FEEDBACK_TAGS_ENUM } from '../utils/constants';
 import { BaseBloomEntity } from './base.entity';
 import { SessionEntity } from './session.entity';
@@ -11,7 +11,11 @@ export class SessionFeedbackEntity extends BaseBloomEntity {
   @ManyToOne(() => SessionEntity, (sessionEntity) => sessionEntity.sessionFeedback, {
     onDelete: 'CASCADE',
   })
+  @JoinColumn({ name: 'sessionId' })
   session: SessionEntity;
+
+  @Column({ name: 'sessionId' })
+  sessionId: string;
 
   @Column()
   feedbackTags: FEEDBACK_TAGS_ENUM;

--- a/src/resource-feedback/resource-feedback.controller.ts
+++ b/src/resource-feedback/resource-feedback.controller.ts
@@ -1,5 +1,6 @@
-import { Body, Controller, Post } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { FirebaseAuthGuard } from 'src/firebase/firebase-auth.guard';
 import { ControllerDecorator } from 'src/utils/controller.decorator';
 import { CreateResourceFeedbackDto } from './dtos/create-resource-feedback.dto';
 import { ResourceFeedbackService } from './resource-feedback.service';
@@ -10,8 +11,9 @@ import { ResourceFeedbackService } from './resource-feedback.service';
 export class ResourceFeedbackController {
   constructor(private readonly resourceFeedbackService: ResourceFeedbackService) {}
 
-  // TODO how do we protect this public endpoint from being abused?
   @Post()
+  @ApiBearerAuth('access-token')
+  @UseGuards(FirebaseAuthGuard)
   @ApiOperation({
     description: 'Stores feedback from a user',
   })

--- a/src/resource-feedback/resource-feedback.module.ts
+++ b/src/resource-feedback/resource-feedback.module.ts
@@ -1,14 +1,57 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { SlackMessageClient } from 'src/api/slack/slack-api';
+import { ZapierWebhookClient } from 'src/api/zapier/zapier-webhook-client';
+import { CrispService } from 'src/crisp/crisp.service';
+import { EventLogEntity } from 'src/entities/event-log.entity';
+import { PartnerAccessEntity } from 'src/entities/partner-access.entity';
+import { PartnerEntity } from 'src/entities/partner.entity';
 import { ResourceFeedbackEntity } from 'src/entities/resource-feedback.entity';
 import { ResourceEntity } from 'src/entities/resource.entity';
+import { SubscriptionUserEntity } from 'src/entities/subscription-user.entity';
+import { SubscriptionEntity } from 'src/entities/subscription.entity';
+import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
+import { UserEntity } from 'src/entities/user.entity';
+import { EventLoggerService } from 'src/event-logger/event-logger.service';
+import { PartnerAccessService } from 'src/partner-access/partner-access.service';
 import { ResourceService } from 'src/resource/resource.service';
+import { ServiceUserProfilesService } from 'src/service-user-profiles/service-user-profiles.service';
+import { SubscriptionUserService } from 'src/subscription-user/subscription-user.service';
+import { SubscriptionService } from 'src/subscription/subscription.service';
+import { TherapySessionService } from 'src/therapy-session/therapy-session.service';
+import { UserService } from 'src/user/user.service';
 import { ResourceFeedbackController } from './resource-feedback.controller';
 import { ResourceFeedbackService } from './resource-feedback.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ResourceFeedbackEntity, ResourceEntity])],
+  imports: [
+    TypeOrmModule.forFeature([
+      ResourceFeedbackEntity,
+      ResourceEntity,
+      PartnerAccessEntity,
+      UserEntity,
+      PartnerEntity,
+      SubscriptionUserEntity,
+      TherapySessionEntity,
+      SubscriptionEntity,
+      EventLogEntity,
+    ]),
+  ],
   controllers: [ResourceFeedbackController],
-  providers: [ResourceFeedbackService, ResourceService],
+  providers: [
+    ResourceFeedbackService,
+    ResourceService,
+    UserService,
+    SubscriptionUserService,
+    TherapySessionService,
+    PartnerAccessService,
+    ServiceUserProfilesService,
+    CrispService,
+    SubscriptionUserService,
+    SubscriptionService,
+    ZapierWebhookClient,
+    SlackMessageClient,
+    EventLoggerService,
+  ],
 })
 export class ResourceFeedbackModule {}

--- a/src/session-feedback/session-feedback.controller.ts
+++ b/src/session-feedback/session-feedback.controller.ts
@@ -13,10 +13,10 @@ export class SessionFeedbackController {
 
   @Post()
   @ApiBearerAuth('access-token')
+  @UseGuards(FirebaseAuthGuard)
   @ApiOperation({
     description: 'Stores feedback from a user',
   })
-  @UseGuards(FirebaseAuthGuard)
   async storeUserFeedback(
     @Body() sessionFeedbackDto: SessionFeedbackDto,
   ): Promise<SessionFeedbackDto> {


### PR DESCRIPTION
### What changes did you make and why did you make them?
Fixes missing `sessionId` on session feedback create. This was missing from Dec 24-Dec 25 and cannot be back filled due to there being no userId on these records (for privacy); we therefore can't attempt to match e.g. user completed session x and then submitted feedback so it was likely for session x.

Fixes missing auth guard on resource feedback post route.