### PR TITLE
Add rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@nestjs/platform-express": "^10.4.12",
     "@nestjs/swagger": "^7.4.0",
     "@nestjs/terminus": "^11.0.0",
+    "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.0",
     "@storyblok/js": "^4.2.5",
     "axios": "^1.11.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,7 @@
 import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { TypeOrmModule, TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { ClsModule } from 'nestjs-cls';
 import { dataSourceOptions } from 'src/typeorm.config';
@@ -32,6 +34,12 @@ import { WebhooksModule } from './webhooks/webhooks.module';
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
+    ThrottlerModule.forRoot([
+      {
+        ttl: 60000, // 60 seconds
+        limit: 100, // 100 requests per TTL window
+      },
+    ]),
     TypeOrmModule.forRoot(dataSourceOptions as TypeOrmModuleOptions),
     ClsModule.forRoot({
       global: true,
@@ -65,6 +73,12 @@ import { WebhooksModule } from './webhooks/webhooks.module';
     ResourceUserModule,
     ResourceFeedbackModule,
     TherapySessionModule,
+  ],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
   ],
 })
 export class AppModule {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1590,6 +1590,11 @@
   dependencies:
     tslib "2.8.1"
 
+"@nestjs/throttler@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@nestjs/throttler/-/throttler-6.5.0.tgz#1ee550a258c4ae697d3978f2c8932adff927439e"
+  integrity sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==
+
 "@nestjs/typeorm@^11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@nestjs/typeorm/-/typeorm-11.0.0.tgz#b0f45d6902396db89e0ac1f4e738c2ff3407b794"


### PR DESCRIPTION
Adds rate limiting using `@nestjs/throttler` package basic setup 

Current configuration:

- ttl: 60000 = 60 seconds (the time window)
- limit: 100 = max requests allowed within that window

The rule: A user can make 100 requests per 60-second window from the same IP address.