### PR TITLE
Add slack deleted users channel

### DIFF
--- a/src/api/slack/slack-api.ts
+++ b/src/api/slack/slack-api.ts
@@ -44,4 +44,25 @@ export class SlackMessageClient {
       return err;
     }
   }
+
+  public async sendMessageToDeletedUsersSlackChannel(
+    text: string,
+  ): Promise<AxiosResponse | string> {
+    if (!isProduction) return; // only send messages in production environment
+
+    try {
+      const response = await apiCall({
+        url: process.env.SLACK_BLOOM_DELETED_USERS_WEBHOOK_URL,
+        type: 'post',
+        data: {
+          text: text,
+        },
+      });
+      this.logger.log('Message sent to slack Deleted Users Channel');
+      return response;
+    } catch (err) {
+      this.logger.error('Unable to sendMessageToDeletedUsersSlackChannel', err);
+      return err;
+    }
+  }
 }

--- a/src/therapy-session/therapy-session.service.ts
+++ b/src/therapy-session/therapy-session.service.ts
@@ -96,7 +96,7 @@ export class TherapySessionService {
         return emailArr.indexOf(email) === index;
       });
 
-    await this.slackMessageClient.sendMessageToTherapySlackChannel(
+    await this.slackMessageClient.sendMessageToDeletedUsersSlackChannel(
       `User has been deleted from bloom - please remove the accounts associated with ${userEmail + emails.join(', ')} from Simplybook, Crisp and from Mailchimp`,
     );
 


### PR DESCRIPTION
Adds function to send deleted users message to a specific channel instead of the shared therapy channel