### PR TITLE
fix: remove SuperAdminAuthGuard from GET /partner/:name

### DIFF
--- a/src/partner/partner.controller.ts
+++ b/src/partner/partner.controller.ts
@@ -36,8 +36,7 @@ export class PartnerController {
   }
 
   @Get(':name')
-  @ApiOperation({ description: 'Returns profile data for a partner' })
-  @UseGuards(SuperAdminAuthGuard)
+  @ApiOperation({ description: 'Returns profile data for a partner. This is a public endpoint and does not require authentication.' })
   @ApiParam({ name: 'name', description: 'Gets partner by name' })
   async getPartner(@Param() params: PartnerParamDto): Promise<IPartner> {
     const partnerResponse = await this.partnerService.getPartnerWithPartnerFeaturesByName(params.name);


### PR DESCRIPTION
## Summary

Fixes #1042

The `GET /v1/partner/:name` endpoint was protected by `SuperAdminAuthGuard`, but partner config data (logos, websites, social links) is non-sensitive and needs to be publicly accessible so the frontend can display partner branding.

As noted in the existing code comment (`// Temporary super admin auth guard`), this was always intended to be opened up.

## Changes

- Removed `@UseGuards(SuperAdminAuthGuard)` from the `GET :name` endpoint
- Updated `@ApiOperation` description to reflect this is now a public endpoint
- Left `SuperAdminAuthGuard` in place on `POST /`, `GET /`, and `PATCH /:id` — those remain admin-only

## Testing

- `GET /v1/partner/:name` can now be called without an auth token and returns partner data
- Admin-only endpoints (`POST /`, `GET /`, `PATCH /:id`) remain protected