### PR TITLE
fix: make GET /partner/:name a public endpoint

### DIFF
--- a/src/partner/partner.controller.ts
+++ b/src/partner/partner.controller.ts
@@ -36,8 +36,7 @@ export class PartnerController {
   }
 
   @Get(':name')
-  @ApiOperation({ description: 'Returns profile data for a partner' })
-  @UseGuards(SuperAdminAuthGuard)
+  @ApiOperation({ description: 'Returns profile data for a partner. This is a public endpoint and does not require authentication.' })
   @ApiParam({ name: 'name', description: 'Gets partner by name' })
   async getPartner(@Param() params: PartnerParamDto): Promise<IPartner> {
     const partnerResponse = await this.partnerService.getPartnerWithPartnerFeaturesByName(params.name);


### PR DESCRIPTION
## Summary

This PR removes the `SuperAdminAuthGuard` from the `GET /v1/partner/:name` endpoint, making it publicly accessible without authentication.

## Why

As part of the effort to move partner config (logos, websites, social links) from the frontend to the database, the frontend will need to call this endpoint to display partner branding. Since this data is non-sensitive (currently hardcoded in the frontend), there is no security concern with opening it up.

The existing comment in the controller already noted `// Temporary super admin auth guard`, confirming this change was always intended.

## Changes

- Removed `@UseGuards(SuperAdminAuthGuard)` from the `GET :name` endpoint
- Updated the `@ApiOperation` description to reflect this is now a public endpoint
- All other endpoints (`POST /`, `GET /`, `PATCH /:id`) retain the `SuperAdminAuthGuard`

Closes #1042