### PR TITLE
fix(partner): remove SuperAdminAuthGuard from GET /partner/:name

### DIFF
--- a/src/partner/partner.controller.ts
+++ b/src/partner/partner.controller.ts
@@ -36,8 +36,7 @@ export class PartnerController {
   }
 
   @Get(':name')
-  @ApiOperation({ description: 'Returns profile data for a partner' })
-  @UseGuards(SuperAdminAuthGuard)
+  @ApiOperation({ description: 'Returns profile data for a partner (public endpoint)' })
   @ApiParam({ name: 'name', description: 'Gets partner by name' })
   async getPartner(@Param() params: PartnerParamDto): Promise<IPartner> {
     const partnerResponse = await this.partnerService.getPartnerWithPartnerFeaturesByName(params.name);


### PR DESCRIPTION
## Summary

Makes the `GET /v1/partner/:name` endpoint publicly accessible.

This endpoint returns non-sensitive partner config data (logos, websites, social links) that the frontend needs to display partner branding. The data is the same as what was previously hardcoded in the frontend.

## Changes

- [x] Removed `@UseGuards(SuperAdminAuthGuard)` decorator from GET :name endpoint
- [x] Removed `@ApiBearerAuth('access-token')` decorator from that endpoint
- [x] Updated @ApiOperation description to indicate it's a public endpoint
- [x] Kept SuperAdminAuthGuard on other endpoints (POST /, GET /, PATCH /:id)

## Testing

- [ ] Run `npm run test`
- [ ] Manually test GET /v1/partner/[test-partner] without auth token

## Related

Ticket 4/6 of #1038 Epic: Extract Partner Config from Frontend to Database
Fixes #1042
