### PR TITLE
feat(partner): add branding/social config columns to DB and CreatePartnerDto

### DIFF
--- a/src/entities/partner.entity.ts
+++ b/src/entities/partner.entity.ts
@@ -16,6 +16,48 @@ export class PartnerEntity extends BaseBloomEntity {
   @Column({ type: Boolean, default: true })
   isActive: boolean;
 
+  @Column({ nullable: true })
+  logo: string;
+
+  @Column({ nullable: true })
+  logoAlt: string;
+
+  @Column({ nullable: true })
+  partnershipLogo: string;
+
+  @Column({ nullable: true })
+  partnershipLogoAlt: string;
+
+  @Column({ nullable: true })
+  bloomGirlIllustration: string;
+
+  @Column({ nullable: true })
+  website: string;
+
+  @Column({ nullable: true })
+  footerLine1: string;
+
+  @Column({ nullable: true })
+  footerLine2: string;
+
+  @Column({ nullable: true })
+  facebookUrl: string;
+
+  @Column({ nullable: true })
+  twitterUrl: string;
+
+  @Column({ nullable: true })
+  instagramUrl: string;
+
+  @Column({ nullable: true })
+  youtubeUrl: string;
+
+  @Column({ nullable: true })
+  tiktokUrl: string;
+
+  @Column({ nullable: true })
+  githubUrl: string;
+
   @OneToMany(() => PartnerAdminEntity, (partnerAdminEntity) => partnerAdminEntity.partner, {
     cascade: true,
   })

--- a/src/migrations/1741251000000-bloom-backend.ts
+++ b/src/migrations/1741251000000-bloom-backend.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class BloomBackend1741251000000 implements MigrationInterface {
+  name = 'BloomBackend1741251000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "partner" ADD "logo" character varying`);
+    await queryRunner.query(`ALTER TABLE "partner" ADD "logoAlt" character varying`);
+    await queryRunner.query(`ALTER TABLE "partner" ADD "partnershipLogo" character varying`);
+    await queryRunner.query(`ALTER TABLE "partner" ADD "partnershipLogoAlt" character varying`);
+    await queryRunner.query(`ALTER TABLE "partner" ADD "bloomGirlIllustration" character varying`);
+    await queryRunner.query(`ALTER TABLE "partner" ADD "website" character varying`);
+    await queryRunner.query(`ALTER TABLE "partner" ADD "footerLine1" character varying`);
+    await queryRunner.query(`ALTER TABLE "partner" ADD "footerLine2" character varying`);
+    await queryRunner.query(`ALTER TABLE "partner" ADD "facebookUrl" character varying`);
+    await queryRunner.query(`ALTER TABLE "partner" ADD "twitterUrl" character varying`);
+    await queryRunner.query(`ALTER TABLE "partner" ADD "instagramUrl" character varying`);
+    await queryRunner.query(`ALTER TABLE "partner" ADD "youtubeUrl" character varying`);
+    await queryRunner.query(`ALTER TABLE "partner" ADD "tiktokUrl" character varying`);
+    await queryRunner.query(`ALTER TABLE "partner" ADD "githubUrl" character varying`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "partner" DROP COLUMN "githubUrl"`);
+    await queryRunner.query(`ALTER TABLE "partner" DROP COLUMN "tiktokUrl"`);
+    await queryRunner.query(`ALTER TABLE "partner" DROP COLUMN "youtubeUrl"`);
+    await queryRunner.query(`ALTER TABLE "partner" DROP COLUMN "instagramUrl"`);
+    await queryRunner.query(`ALTER TABLE "partner" DROP COLUMN "twitterUrl"`);
+    await queryRunner.query(`ALTER TABLE "partner" DROP COLUMN "facebookUrl"`);
+    await queryRunner.query(`ALTER TABLE "partner" DROP COLUMN "footerLine2"`);
+    await queryRunner.query(`ALTER TABLE "partner" DROP COLUMN "footerLine1"`);
+    await queryRunner.query(`ALTER TABLE "partner" DROP COLUMN "website"`);
+    await queryRunner.query(`ALTER TABLE "partner" DROP COLUMN "bloomGirlIllustration"`);
+    await queryRunner.query(`ALTER TABLE "partner" DROP COLUMN "partnershipLogoAlt"`);
+    await queryRunner.query(`ALTER TABLE "partner" DROP COLUMN "partnershipLogo"`);
+    await queryRunner.query(`ALTER TABLE "partner" DROP COLUMN "logoAlt"`);
+    await queryRunner.query(`ALTER TABLE "partner" DROP COLUMN "logo"`);
+  }
+}

--- a/src/partner/dtos/create-partner.dto.ts
+++ b/src/partner/dtos/create-partner.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDefined } from 'class-validator';
+import { IsDefined, IsOptional, IsString, IsUrl } from 'class-validator';
 import { SecureInput } from '../../utils/sanitization.decorators';
 
 export class CreatePartnerDto {
@@ -7,4 +7,74 @@ export class CreatePartnerDto {
   @IsDefined()
   @ApiProperty({ type: String })
   name: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({ type: String, required: false })
+  logo?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({ type: String, required: false })
+  logoAlt?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({ type: String, required: false })
+  partnershipLogo?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({ type: String, required: false })
+  partnershipLogoAlt?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({ type: String, required: false })
+  bloomGirlIllustration?: string;
+
+  @IsOptional()
+  @IsUrl()
+  @ApiProperty({ type: String, required: false })
+  website?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({ type: String, required: false })
+  footerLine1?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({ type: String, required: false })
+  footerLine2?: string;
+
+  @IsOptional()
+  @IsUrl()
+  @ApiProperty({ type: String, required: false })
+  facebookUrl?: string;
+
+  @IsOptional()
+  @IsUrl()
+  @ApiProperty({ type: String, required: false })
+  twitterUrl?: string;
+
+  @IsOptional()
+  @IsUrl()
+  @ApiProperty({ type: String, required: false })
+  instagramUrl?: string;
+
+  @IsOptional()
+  @IsUrl()
+  @ApiProperty({ type: String, required: false })
+  youtubeUrl?: string;
+
+  @IsOptional()
+  @IsUrl()
+  @ApiProperty({ type: String, required: false })
+  tiktokUrl?: string;
+
+  @IsOptional()
+  @IsUrl()
+  @ApiProperty({ type: String, required: false })
+  githubUrl?: string;
 }


### PR DESCRIPTION
## Summary

Implements tickets **#1039** and **#1040** from Epic #1038 (Extract Partner Config from Frontend to Database).

## Changes

### Migration (`1741251000000-bloom-backend.ts`)
Adds 14 nullable `varchar` columns to the `partner` table:
- `logo`, `logoAlt` — partner logo URL and alt text
- `partnershipLogo`, `partnershipLogoAlt` — co-branded logo URL and alt text
- `bloomGirlIllustration` — partner-specific illustration URL
- `website` — partner website URL
- `footerLine1`, `footerLine2` — footer text (i18n key or plain text)
- `facebookUrl`, `twitterUrl`, `instagramUrl`, `youtubeUrl`, `tiktokUrl`, `githubUrl` — social links

All columns are nullable so existing data is unaffected.

### Entity (`src/entities/partner.entity.ts`)
Added `@Column({ nullable: true })` decorators for each new field to keep the entity in sync with the migration.

### DTO (`src/partner/dtos/create-partner.dto.ts`)
Added all 14 fields as optional properties with:
- `@IsOptional()` — field is not required
- `@IsString()` or `@IsUrl()` — type validation (`@IsUrl()` applied to `website` and all `*Url` fields)
- `@ApiProperty({ type: String, required: false })` — Swagger documentation

The existing `createPartner` service method uses `this.partnerRepository.create(createPartnerDto)` which automatically picks up the new fields since they match entity column names — no service changes needed.

## Testing
- [ ] Run `npm run test` — existing tests should pass unchanged
- [ ] Manually test `POST /v1/partner` with new fields to confirm they persist

Closes #1039
Closes #1040