### PR TITLE
fix: remove SuperAdminAuthGuard from GET /partner/:name

### DIFF
--- a/src/partner/partner.controller.ts
+++ b/src/partner/partner.controller.ts
@@ -36,8 +36,7 @@ export class PartnerController {
   }
 
   @Get(':name')
-  @ApiOperation({ description: 'Returns profile data for a partner' })
-  @UseGuards(SuperAdminAuthGuard)
+  @ApiOperation({ description: 'Returns profile data for a partner. This is a public endpoint — no authentication required.' })
   @ApiParam({ name: 'name', description: 'Gets partner by name' })
   async getPartner(@Param() params: PartnerParamDto): Promise<IPartner> {
     const partnerResponse = await this.partnerService.getPartnerWithPartnerFeaturesByName(params.name);


### PR DESCRIPTION
## Summary

This PR addresses issue #1042 by removing the `SuperAdminAuthGuard` from the `GET /v1/partner/:name` endpoint.

## Changes

- Removed `@UseGuards(SuperAdminAuthGuard)` decorator from the `GET :name` endpoint in `src/partner/partner.controller.ts`
- Updated the `@ApiOperation` description to clarify this is now a public endpoint
- All other endpoints (`POST /`, `GET /`, `PATCH /:id`) retain their `SuperAdminAuthGuard` protection

## Why

As the frontend moves partner config (logos, branding, social links) from hardcoded values to a database-backed API, the `GET /v1/partner/:name` endpoint needs to be publicly accessible so the frontend can fetch partner branding without requiring admin authentication. The data returned is non-sensitive (same data previously hardcoded in the frontend), so there is no security concern with this change.

Closes #1042