### PR TITLE
fix: remove SuperAdminAuthGuard from GET /partner/:name

### DIFF
--- a/src/partner/partner.controller.ts
+++ b/src/partner/partner.controller.ts
@@ -36,8 +36,7 @@ export class PartnerController {
   }
 
   @Get(':name')
-  @ApiOperation({ description: 'Returns profile data for a partner' })
-  @UseGuards(SuperAdminAuthGuard)
+  @ApiOperation({ description: 'Returns profile data for a partner. This is a public endpoint.' })
   @ApiParam({ name: 'name', description: 'Gets partner by name' })
   async getPartner(@Param() params: PartnerParamDto): Promise<IPartner> {
     const partnerResponse = await this.partnerService.getPartnerWithPartnerFeaturesByName(params.name);


### PR DESCRIPTION
## Summary

Closes #1042

The `GET /v1/partner/:name` endpoint was protected by `SuperAdminAuthGuard`, preventing the frontend from accessing public partner branding data (logos, websites, social links). As noted in the existing code comment, this guard was always intended to be temporary.

## Changes

- Removed `@UseGuards(SuperAdminAuthGuard)` from the `GET :name` endpoint
- Updated `@ApiOperation` description to indicate this is a public endpoint

All other endpoints (`POST /`, `GET /`, `PATCH /:id`) retain the `SuperAdminAuthGuard` as they should remain admin-only.

## Testing

- Verified existing tests pass with `npm run test`
- The endpoint can now be called without an auth token and will return partner data