### PR TITLE
Fix crisp + mailchimp bug

### DIFF
--- a/src/crisp/crisp.service.spec.ts
+++ b/src/crisp/crisp.service.spec.ts
@@ -185,7 +185,7 @@ describe('CrispService', () => {
       expect(mockWebsite.updatePeopleData).toHaveBeenCalledWith(
         crispWebsiteId,
         'test@example.com',
-        customFields,
+        { data: customFields },
       );
       expect(response).toEqual(expectedResponse);
     });

--- a/src/crisp/crisp.service.ts
+++ b/src/crisp/crisp.service.ts
@@ -82,11 +82,7 @@ export class CrispService {
     }
 
     try {
-      const crispProfile = CrispClient.website.addNewPeopleProfile(
-        crispWebsiteId,
-        newPeopleProfile,
-      );
-      return crispProfile;
+      return await CrispClient.website.addNewPeopleProfile(crispWebsiteId, newPeopleProfile);
     } catch (error) {
       throw new Error(`Create crisp profile API call failed: ${error?.message || 'unknown error'}`, {
         cause: error,
@@ -104,12 +100,7 @@ export class CrispService {
     }
 
     try {
-      const crispProfile = CrispClient.website.updatePeopleProfile(
-        crispWebsiteId,
-        email,
-        peopleProfile,
-      );
-      return crispProfile;
+      return await CrispClient.website.updatePeopleProfile(crispWebsiteId, email, peopleProfile);
     } catch (error) {
       // Only handle profile not found errors (404, not_found, or profile-related errors)
       if (this.isProfileNotFoundError(error)) {
@@ -144,16 +135,18 @@ export class CrispService {
     }
 
     const params = this.toCrispDataParams(peopleData);
+    // crisp-api's typings incorrectly expect a flat object, but the REST API and crisp-api
+    // EXAMPLES.md both require the payload wrapped in { data: ... }. Cast to bypass the wrong type.
+    const body = { data: params } as unknown as Record<string, string | number | boolean>;
 
     try {
-      const crispPeopleData = CrispClient.website.updatePeopleData(crispWebsiteId, email, params);
-      return crispPeopleData;
+      return await CrispClient.website.updatePeopleData(crispWebsiteId, email, body);
     } catch (error) {
       // Only handle profile not found errors (404, not_found, or profile-related errors)
       if (this.isProfileNotFoundError(error)) {
         try {
           await this.createCrispProfile({ email });
-          return await CrispClient.website.updatePeopleData(crispWebsiteId, email, params);
+          return await CrispClient.website.updatePeopleData(crispWebsiteId, email, body);
         } catch {
           throw new Error(
             `Update crisp profile API call failed: ${error?.message || 'unknown error'}`,

--- a/src/service-user-profiles/service-user-profiles.service.ts
+++ b/src/service-user-profiles/service-user-profiles.service.ts
@@ -53,20 +53,18 @@ export class ServiceUserProfilesService {
       return;
     }
 
+    const userData = this.serializeUserData(user);
+    const partnerData = this.serializePartnerAccessData(
+      partnerAccess ? [{ ...partnerAccess, partner }] : [],
+    );
+    const userSignedUpAt = user.createdAt?.toISOString();
+
     try {
-      const userData = this.serializeUserData(user);
-
-      const partnerData = this.serializePartnerAccessData(
-        partnerAccess ? [{ ...partnerAccess, partner }] : [],
-      );
-
       await this.crispService.createCrispProfile({
         email: email,
         person: { nickname: user.name, locales: [user.signUpLanguage || LANGUAGE_DEFAULT] },
         segments: this.serializeCrispPartnerSegments(partner ? [partner] : []),
       });
-
-      const userSignedUpAt = user.createdAt?.toISOString();
 
       await this.crispService.updateCrispPeopleData(
         {
@@ -76,7 +74,12 @@ export class ServiceUserProfilesService {
         },
         email,
       );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'unknown error';
+      logger.error(`Create Crisp user profile error: ${message}`);
+    }
 
+    try {
       const mailchimpMergeFields = {
         SIGNUPD: userSignedUpAt,
         ...userData.mailchimpSchema.merge_fields,
@@ -89,11 +92,12 @@ export class ServiceUserProfilesService {
         ...partnerData.mailchimpSchema,
         merge_fields: mailchimpMergeFields,
       });
-
-      logger.log('Create user: updated service user profiles');
     } catch (error) {
-      logger.error(`Create service user profiles error: ${error?.message || 'unknown error'}`);
+      const message = error instanceof Error ? error.message : 'unknown error';
+      logger.error(`Create Mailchimp user profile error: ${message}`);
     }
+
+    logger.log('Create user: updated service user profiles');
   }
 
   async updateServiceUserProfilesUser(
@@ -108,6 +112,8 @@ export class ServiceUserProfilesService {
       logger.log('Skipping service user profile update for Cypress test email');
       return;
     }
+
+    const userData = this.serializeUserData(user);
 
     try {
       if (isCrispBaseUpdateRequired) {
@@ -124,8 +130,13 @@ export class ServiceUserProfilesService {
         );
       }
 
-      const userData = this.serializeUserData(user);
       await this.crispService.updateCrispPeopleData(userData.crispSchema, email);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'unknown error';
+      logger.error(`Update Crisp user profile error - ${message}`);
+    }
+
+    try {
       await updateMailchimpProfile(
         {
           ...userData.mailchimpSchema,
@@ -133,12 +144,12 @@ export class ServiceUserProfilesService {
         },
         existingEmail,
       );
-      logger.log('Updated service user profiles user');
     } catch (error) {
-      logger.error(
-        `Update service user profiles user error - ${error?.message || 'unknown error'}`,
-      );
+      const message = error instanceof Error ? error.message : 'unknown error';
+      logger.error(`Update Mailchimp user profile error - ${message}`);
     }
+
+    logger.log('Updated service user profiles user');
   }
 
   async updateServiceUserProfilesPartnerAccess(
@@ -150,6 +161,8 @@ export class ServiceUserProfilesService {
       return;
     }
 
+    const partnerAccessData = this.serializePartnerAccessData(partnerAccesses);
+
     try {
       const partners = partnerAccesses.map((pa) => pa.partner);
       await this.crispService.updateCrispProfileBase(
@@ -159,13 +172,17 @@ export class ServiceUserProfilesService {
         email,
       );
 
-      const partnerAccessData = this.serializePartnerAccessData(partnerAccesses);
       await this.crispService.updateCrispPeopleData(partnerAccessData.crispSchema, email);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'unknown error';
+      logger.error(`Update Crisp partner access error - ${message}`);
+    }
+
+    try {
       await updateMailchimpProfile(partnerAccessData.mailchimpSchema, email);
     } catch (error) {
-      logger.error(
-        `Update service user profiles partner access error - ${error?.message || 'unknown error'}`,
-      );
+      const message = error instanceof Error ? error.message : 'unknown error';
+      logger.error(`Update Mailchimp partner access error - ${message}`);
     }
   }
 
@@ -175,14 +192,20 @@ export class ServiceUserProfilesService {
       return;
     }
 
+    const therapyData = this.serializeTherapyData(partnerAccesses);
+
     try {
-      const therapyData = this.serializeTherapyData(partnerAccesses);
       await this.crispService.updateCrispPeopleData(therapyData.crispSchema, email);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'unknown error';
+      logger.error(`Update Crisp therapy error - ${message}`);
+    }
+
+    try {
       await updateMailchimpProfile(therapyData.mailchimpSchema, email);
     } catch (error) {
-      logger.error(
-        `Update service user profiles therapy error - ${error?.message || 'unknown error'}`,
-      );
+      const message = error instanceof Error ? error.message : 'unknown error';
+      logger.error(`Update Mailchimp therapy error - ${message}`);
     }
   }
 
@@ -192,14 +215,20 @@ export class ServiceUserProfilesService {
       return;
     }
 
+    const courseData = this.serializeCourseData(courseUser);
+
     try {
-      const courseData = this.serializeCourseData(courseUser);
       await this.crispService.updateCrispPeopleData(courseData.crispSchema, email);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'unknown error';
+      logger.error(`Update Crisp course error - ${message}`);
+    }
+
+    try {
       await updateMailchimpProfile(courseData.mailchimpSchema, email);
     } catch (error) {
-      logger.error(
-        `Update service user profiles course error - ${error?.message || 'unknown error'}`,
-      );
+      const message = error instanceof Error ? error.message : 'unknown error';
+      logger.error(`Update Mailchimp course error - ${message}`);
     }
   }
 


### PR DESCRIPTION
Fixes crisp formatting bug which was preventing mailchimp accounts from being created. This PR separated the calls/errors

The rollbar error [Create service user profiles error: invalid_data](https://app.rollbar.com/a/chayn/fix/item/bloom-backend/3955) shows the root of the issue