### PR TITLE
Fix staging reporting

### DIFF
--- a/src/api/slack/slack-api.ts
+++ b/src/api/slack/slack-api.ts
@@ -73,12 +73,19 @@ export class SlackMessageClient {
     }
   }
 
+  /**
+   * Unlike the other Slack channels above (which gate on `isProduction` to
+   * avoid accidentally messaging real user-facing channels from
+   * dev/staging), the reporting channel is explicitly operational — it's
+   * where the reporting digest lands and staging runs need to land there
+   * too so scheduled-run tests are end-to-end visible. No environment gate.
+   * The apiCall will simply 4xx/5xx if `slackReportingWebhookUrl` is
+   * missing locally, caught below.
+   */
   public async sendMessageToReportingChannel(
     blocks: unknown[],
-    opts: { force?: boolean; fallbackText?: string } = {},
+    opts: { fallbackText?: string } = {},
   ): Promise<AxiosResponse | string> {
-    if (!isProduction && !opts.force) return;
-
     try {
       const response = await apiCall({
         url: slackReportingWebhookUrl,

--- a/src/reporting/reporting.constants.ts
+++ b/src/reporting/reporting.constants.ts
@@ -1,8 +1,20 @@
+// ============================================================================
+// ⚠️  TEMPORARY TEST CONFIGURATION — DO NOT MERGE
+// ----------------------------------------------------------------------------
+// All four period crons are set to fire at 19:28 Europe/London on every day
+// for a one-off end-to-end test (all four digests will post simultaneously
+// to Slack). This also means the idempotency guard will kick in after the
+// first fire — only the first minute-match per period-slot actually posts,
+// subsequent fires log `already claimed` and exit. That's expected and
+// validates the idempotency path.
+//
+// REVERT before merge — original values are commented beside each line.
+// ============================================================================
 export const CRON_EXPRESSIONS = {
-  daily: '0 9 * * *', // 09:00 every day
-  weekly: '0 9 * * MON', // 09:00 every Monday
-  monthly: '0 9 1 * *', // 09:00 on the 1st of every month
-  quarterly: '0 9 1 1,4,7,10 *', // 09:00 on the 1st of Jan/Apr/Jul/Oct
+  daily: '35 22 * * *', // ORIGINAL: '0 9 * * *'
+  weekly: '35 22 * * *', // ORIGINAL: '0 9 * * MON'
+  monthly: '35 22 * * *', // ORIGINAL: '0 9 1 * *'
+  quarterly: '35 22 * * *', // ORIGINAL: '0 9 1 1,4,7,10 *'
 } as const;
 
 // Slack's absolute cap is 50 blocks per message; stop short at 45 so the

--- a/src/reporting/reporting.scheduler.ts
+++ b/src/reporting/reporting.scheduler.ts
@@ -39,7 +39,7 @@ export class ReportingScheduler {
   }
 
   private async fire(period: ReportPeriod): Promise<void> {
-    this.logger.log(`ReportingScheduler: firing ${period} at ${reportingTimezone} 09:00`);
+    this.logger.log(`ReportingScheduler: firing ${period} (tz=${reportingTimezone})`);
     try {
       await this.reportingService.run(period, { trigger: 'scheduled' });
     } catch (err) {

--- a/src/reporting/reporting.service.ts
+++ b/src/reporting/reporting.service.ts
@@ -103,7 +103,6 @@ export class ReportingService {
 
     try {
       const slackResponse = await this.slackMessageClient.sendMessageToReportingChannel(blocks, {
-        force: opts.force === true,
         fallbackText,
       });
       await this.markSent(runId, payload, slackResponse);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -159,8 +159,10 @@ export const slackReportingWebhookUrl = getEnv(
   'SLACK_REPORTING_WEBHOOK_URL',
 );
 
-export const reportingTimezone =
-  getEnv(process.env.REPORTING_TIMEZONE, 'REPORTING_TIMEZONE') || 'Europe/London';
+// Optional with a default — read process.env directly rather than via
+// getEnv() which would log a misleading "Missing required variable" warning
+// on every boot when the var isn't set (it isn't required).
+export const reportingTimezone = process.env.REPORTING_TIMEZONE || 'Europe/London';
 
 export const ga4PropertyId = getEnv(process.env.GA4_PROPERTY_ID, 'GA4_PROPERTY_ID');
 export const ga4ServiceAccountKeyJson = getEnv(


### PR DESCRIPTION
Fixes staging reporting flow by removing `!production` prevention. changes time to test now in staging