### PR TITLE
feat: add new simplybook endpoint to handle therapy CRUD behind 2FA a…

### DIFF
--- a/docs/configure-env.md
+++ b/docs/configure-env.md
@@ -35,14 +35,16 @@ FIREBASE_MEASUREMENT_ID=
 # REQUIRED VARIABLES FOR TESTING
 #---------------------------------------------------------------
 # MOCK VALUES (can replace with real values or new mocks in same format)
-SIMPLYBOOK_CREDENTIALS='{"login":"testlogin","password":"testpassword","company":"testcompany"}'
+SIMPLYBOOK_CREDENTIALS='{"login":"testlogin","password":"api_user_key_customapikey","company":"testcompany"}'
 SIMPLYBOOK_COMPANY_NAME=testcompany
+SIMPLYBOOK_WEBHOOK_SECRET=generate-your-own-secret
+SIMPLYBOOK_TOTP_SECRET= # Required when 2FA is enabled on the Simplybook admin account
 
 # OPTIONAL VARIABLES
 #---------------------------------------------------------------
 ROLLBAR_ENV=development # Rollbar logging
 ROLLBAR_TOKEN= # Rollbar logging
-ZAPIER_TOKEN= # Zapier automation
+ZAPIER_TOKEN= # Zapier automation (legacy - see SIMPLYBOOK_WEBHOOK_SECRET)
 SLACK_WEBHOOK_URL= # Slack messaging bots
 FRONT_SUPPORT_EMAIL= # (optional) Front sender address used to distinguish agent replies in chat history; defaults to support@bloom.chayn.co
 MAILCHIMP_API_KEY= # Email messaging
@@ -61,3 +63,21 @@ The frontend and backend each have _required_ and _optional_ environment variabl
 Note: Variables provided by Chayn are public, not linked to production, and subject to change at any time. Check for updates if you are experiencing problems. The absence of some optional environment variables may result in test failures. If you require an optional environment variable and cannot acquire it yourself (some must be connected to Chayn in some way), please reach out to the team in GitHub’s issue discussions.
 
 **Please notify us if creating new environment variables in your PR so we can add it to Render before release deployment.**
+
+## Simplybook Variables
+
+`SIMPLYBOOK_CREDENTIALS` must be a JSON string with the following shape:
+
+```json
+{ "login": "<api_user_key_or_login>", "password": "<password>", "company": "<company_login>" }
+```
+
+For production, use a Simplybook **API User Key** (`api_user_key_...`) as the `login` value — this bypasses IP verification restrictions on the admin API.
+
+`SIMPLYBOOK_WEBHOOK_SECRET` is the shared secret used to authenticate incoming webhooks from Simplybook at `POST /api/webhooks/simplybook-admin`. Configure the same value as the `?token=` query parameter in the Simplybook webhook callback URL:
+
+```
+https://<your-domain>/api/webhooks/simplybook-admin?token=<SIMPLYBOOK_WEBHOOK_SECRET>
+```
+
+`SIMPLYBOOK_TOTP_SECRET` is required when 2FA is enabled on the Simplybook admin account. It is the base32 TOTP secret shown during 2FA setup (the same secret you scan into an authenticator app). Leave unset if 2FA is not enabled.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "luxon": "^3.7.2",
     "nestjs-cls": "^6.2.0",
     "newrelic": "^13.19.2",
+    "otplib": "^12.0.1",
     "pg": "^8.20.0",
     "pg-connection-string": "^2.7.0",
     "reflect-metadata": "^0.2.1",

--- a/src/api/simplybook/simplybook-api.ts
+++ b/src/api/simplybook/simplybook-api.ts
@@ -16,6 +16,7 @@ import axios from 'axios';
 import { authenticator } from 'otplib';
 import { Logger } from 'src/logger/logger';
 import {
+  isProduction,
   simplybookCompanyName,
   simplybookCredentials,
   simplybookTotpSecret,
@@ -52,21 +53,24 @@ let cachedToken: { token: string; expiresAt: number } | null = null;
 let inFlightAuth: Promise<string> | null = null;
 
 const performAuth = async (): Promise<string> => {
-  const response = await axios.post(
-    `${SIMPLYBOOK_API_BASE_URL}/auth`,
-    JSON.parse(simplybookCredentials),
-    {
-      headers: {
-        'Content-Type': 'application/json',
-      },
+  const credentials = JSON.parse(simplybookCredentials);
+  const response = await axios.post(`${SIMPLYBOOK_API_BASE_URL}/auth`, credentials, {
+    headers: {
+      'Content-Type': 'application/json',
     },
-  );
+  });
 
   let token: string;
 
   if (!response.data.require2fa) {
     token = response.data.token;
   } else {
+    if (!simplybookTotpSecret && isProduction) {
+      throw new Error(
+        'Simplybook requires 2FA but SIMPLYBOOK_TOTP_SECRET is not configured. ' +
+          'Set the env var to the base32 TOTP secret from Simplybook admin 2FA setup.',
+      );
+    }
     const normalisedSecret = simplybookTotpSecret.toUpperCase().replace(/\s/g, '');
     // If fewer than 3 seconds remain in the current 30s window, wait for the next one
     // to avoid sending a code that expires before Simplybook receives the request
@@ -75,7 +79,6 @@ const performAuth = async (): Promise<string> => {
       await new Promise((resolve) => setTimeout(resolve, (secondsRemaining + 1) * 1000));
     }
     const code = authenticator.generate(normalisedSecret);
-    const credentials = JSON.parse(simplybookCredentials);
     const twoFaResponse = await axios.post(
       `${SIMPLYBOOK_API_BASE_URL}/auth/2fa`,
       {
@@ -122,7 +125,7 @@ export const getBookingId: (bookingCode: string) => Promise<number> = async (
 
   try {
     const bookingsResponse = await axios.get(
-      `${SIMPLYBOOK_API_BASE_URL}/bookings?filter[search]=${bookingCode}`,
+      `${SIMPLYBOOK_API_BASE_URL}/bookings?filter[search]=${encodeURIComponent(bookingCode)}`,
       {
         headers: {
           'Content-Type': 'application/json',
@@ -198,5 +201,7 @@ const handleError = (message: string, error) => {
   // Don't log error.response.data — booking responses contain client emails and other PII.
   // The caller's message already includes the bookingId/bookingCode to identify the record.
   logger.error(`${message}: ${errorDetail}${status ? ` (status ${status})` : ''}`);
-  throw new Error(`${message}: ${errorDetail}`);
+  // Preserve the original error (stack trace, AxiosError properties) via Error.cause
+  // so downstream callers can inspect it if they need to differentiate failure modes.
+  throw new Error(`${message}: ${errorDetail}`, { cause: error });
 };

--- a/src/api/simplybook/simplybook-api.ts
+++ b/src/api/simplybook/simplybook-api.ts
@@ -1,7 +1,9 @@
 import axios from 'axios';
 import { Logger } from 'src/logger/logger';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { authenticator } = require('otplib');
 
-import { simplybookCompanyName, simplybookCredentials } from 'src/utils/constants';
+import { simplybookCompanyName, simplybookCredentials, simplybookTotpSecret } from 'src/utils/constants';
 
 type BookingResponse = {
   client: {
@@ -11,10 +13,29 @@ type BookingResponse = {
   code: string;
 };
 
+export type SimplybookBookingDetails = {
+  id: number;
+  code: string;
+  start_datetime: string;
+  end_datetime: string;
+  service: { name: string };
+  provider: { name: string; email: string };
+  client: { email: string };
+  additional_fields: Array<{ id: number; field_name: string; value: string | null }>;
+};
+
 const SIMPLYBOOK_API_BASE_URL = 'https://user-api-v2.simplybook.me/admin';
 const logger = new Logger('SimplybookAPI');
 
+// Simplybook tokens last 1 hour — cache for 55 minutes to avoid re-authenticating on every call
+const TOKEN_TTL_MS = 55 * 60 * 1000;
+let cachedToken: { token: string; expiresAt: number } | null = null;
+
 const getAuthToken: () => Promise<string> = async () => {
+  if (cachedToken && Date.now() < cachedToken.expiresAt) {
+    return cachedToken.token;
+  }
+
   try {
     const response = await axios.post(
       `${SIMPLYBOOK_API_BASE_URL}/auth`,
@@ -25,7 +46,36 @@ const getAuthToken: () => Promise<string> = async () => {
         },
       },
     );
-    return response.data.token;
+
+    let token: string;
+
+    if (!response.data.require2fa) {
+      token = response.data.token;
+    } else {
+      const normalisedSecret = simplybookTotpSecret.toUpperCase().replace(/\s/g, '');
+      // If fewer than 3 seconds remain in the current 30s window, wait for the next one
+      // to avoid sending a code that expires before Simplybook receives the request
+      const secondsRemaining = 30 - (Math.floor(Date.now() / 1000) % 30);
+      if (secondsRemaining <= 3) {
+        await new Promise((resolve) => setTimeout(resolve, (secondsRemaining + 1) * 1000));
+      }
+      const code = authenticator.generate(normalisedSecret).toString();
+      const credentials = JSON.parse(simplybookCredentials);
+      const twoFaResponse = await axios.post(
+        `${SIMPLYBOOK_API_BASE_URL}/auth/2fa`,
+        {
+          company: credentials.company,
+          session_id: response.data.auth_session_id,
+          type: 'ga',
+          code,
+        },
+        { headers: { 'Content-Type': 'application/json' } },
+      );
+      token = twoFaResponse.data.token;
+    }
+
+    cachedToken = { token, expiresAt: Date.now() + TOKEN_TTL_MS };
+    return token;
   } catch (error) {
     handleError('Failed to authenticate against Simplybook API.', error);
   }
@@ -81,8 +131,37 @@ export const cancelBooking: (id: number) => Promise<BookingResponse[]> = async (
   }
 };
 
+export const getBookingDetails: (id: number) => Promise<SimplybookBookingDetails> = async (
+  id: number,
+) => {
+  const token = await getAuthToken();
+
+  try {
+    const response = await axios.get(`${SIMPLYBOOK_API_BASE_URL}/bookings/${id}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Company-Login': simplybookCompanyName,
+        'X-Token': `${token}`,
+      },
+    });
+
+    if (!response?.data) {
+      throw new Error('No data returned from Simplybook API for booking details');
+    }
+
+    return response.data;
+  } catch (error) {
+    handleError(`Failed to retrieve booking details for id ${id} from Simplybook.`, error);
+  }
+};
+
 const handleError = (message: string, error) => {
+  if (error?.response?.status === 401) {
+    cachedToken = null;
+  }
   const errorDetail = error?.message || error?.code || 'unknown error';
+  const responseData = error?.response?.data;
   logger.error(`${message}: ${errorDetail}`);
+  if (responseData) logger.error(`Simplybook response body: ${JSON.stringify(responseData)}`);
   throw new Error(`${message}: ${errorDetail}`);
 };

--- a/src/api/simplybook/simplybook-api.ts
+++ b/src/api/simplybook/simplybook-api.ts
@@ -1,3 +1,17 @@
+/**
+ * Simplybook REST Admin API client (https://user-api-v2.simplybook.me/admin).
+ *
+ * Auth model: login + password via POST /auth, returning a token used in `X-Token` headers.
+ * When 2FA is enabled on the Simplybook account, /auth responds with `require2fa: true` and
+ * we follow up with POST /auth/2fa carrying a TOTP code generated from SIMPLYBOOK_TOTP_SECRET.
+ *
+ * Future migration: Simplybook also exposes a "public" JSON-RPC API at https://user-api.simplybook.me
+ * (Company Public Service API) that authenticates via an API key + secret key signature pattern
+ * (`md5(bookingId + bookingHash + secretKey)`). It is not affected by admin 2FA and is the
+ * recommended path for server-to-server integrations. Migrating the three methods used here
+ * (getBookingId, cancelBooking, getBookingDetails → public `getBooking`, `cancelBooking`) would
+ * let us drop the 2FA flow, the token mutex, and the SIMPLYBOOK_TOTP_SECRET env var.
+ */
 import axios from 'axios';
 import { authenticator } from 'otplib';
 import { Logger } from 'src/logger/logger';

--- a/src/api/simplybook/simplybook-api.ts
+++ b/src/api/simplybook/simplybook-api.ts
@@ -1,9 +1,11 @@
 import axios from 'axios';
+import { authenticator } from 'otplib';
 import { Logger } from 'src/logger/logger';
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const { authenticator } = require('otplib');
-
-import { simplybookCompanyName, simplybookCredentials, simplybookTotpSecret } from 'src/utils/constants';
+import {
+  simplybookCompanyName,
+  simplybookCredentials,
+  simplybookTotpSecret,
+} from 'src/utils/constants';
 
 type BookingResponse = {
   client: {
@@ -30,54 +32,72 @@ const logger = new Logger('SimplybookAPI');
 // Simplybook tokens last 1 hour — cache for 55 minutes to avoid re-authenticating on every call
 const TOKEN_TTL_MS = 55 * 60 * 1000;
 let cachedToken: { token: string; expiresAt: number } | null = null;
+// Concurrent callers share a single in-flight auth so we don't fire /auth + 2FA
+// multiple times in parallel — avoids redundant API calls, duplicate TOTP code
+// submissions, and any rate-limiting on the auth endpoints.
+let inFlightAuth: Promise<string> | null = null;
+
+const performAuth = async (): Promise<string> => {
+  const response = await axios.post(
+    `${SIMPLYBOOK_API_BASE_URL}/auth`,
+    JSON.parse(simplybookCredentials),
+    {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  );
+
+  let token: string;
+
+  if (!response.data.require2fa) {
+    token = response.data.token;
+  } else {
+    const normalisedSecret = simplybookTotpSecret.toUpperCase().replace(/\s/g, '');
+    // If fewer than 3 seconds remain in the current 30s window, wait for the next one
+    // to avoid sending a code that expires before Simplybook receives the request
+    const secondsRemaining = 30 - (Math.floor(Date.now() / 1000) % 30);
+    if (secondsRemaining <= 3) {
+      await new Promise((resolve) => setTimeout(resolve, (secondsRemaining + 1) * 1000));
+    }
+    const code = authenticator.generate(normalisedSecret);
+    const credentials = JSON.parse(simplybookCredentials);
+    const twoFaResponse = await axios.post(
+      `${SIMPLYBOOK_API_BASE_URL}/auth/2fa`,
+      {
+        company: credentials.company,
+        session_id: response.data.auth_session_id,
+        type: 'ga',
+        code,
+      },
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+    token = twoFaResponse.data.token;
+  }
+
+  cachedToken = { token, expiresAt: Date.now() + TOKEN_TTL_MS };
+  return token;
+};
 
 const getAuthToken: () => Promise<string> = async () => {
   if (cachedToken && Date.now() < cachedToken.expiresAt) {
     return cachedToken.token;
   }
 
-  try {
-    const response = await axios.post(
-      `${SIMPLYBOOK_API_BASE_URL}/auth`,
-      JSON.parse(simplybookCredentials),
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      },
-    );
+  if (inFlightAuth) {
+    return inFlightAuth;
+  }
 
-    let token: string;
-
-    if (!response.data.require2fa) {
-      token = response.data.token;
-    } else {
-      const normalisedSecret = simplybookTotpSecret.toUpperCase().replace(/\s/g, '');
-      // If fewer than 3 seconds remain in the current 30s window, wait for the next one
-      // to avoid sending a code that expires before Simplybook receives the request
-      const secondsRemaining = 30 - (Math.floor(Date.now() / 1000) % 30);
-      if (secondsRemaining <= 3) {
-        await new Promise((resolve) => setTimeout(resolve, (secondsRemaining + 1) * 1000));
-      }
-      const code = authenticator.generate(normalisedSecret).toString();
-      const credentials = JSON.parse(simplybookCredentials);
-      const twoFaResponse = await axios.post(
-        `${SIMPLYBOOK_API_BASE_URL}/auth/2fa`,
-        {
-          company: credentials.company,
-          session_id: response.data.auth_session_id,
-          type: 'ga',
-          code,
-        },
-        { headers: { 'Content-Type': 'application/json' } },
-      );
-      token = twoFaResponse.data.token;
-    }
-
-    cachedToken = { token, expiresAt: Date.now() + TOKEN_TTL_MS };
-    return token;
-  } catch (error) {
+  inFlightAuth = performAuth().catch((error) => {
     handleError('Failed to authenticate against Simplybook API.', error);
+    // handleError always throws; satisfies the type checker.
+    throw error;
+  });
+
+  try {
+    return await inFlightAuth;
+  } finally {
+    inFlightAuth = null;
   }
 };
 
@@ -160,8 +180,9 @@ const handleError = (message: string, error) => {
     cachedToken = null;
   }
   const errorDetail = error?.message || error?.code || 'unknown error';
-  const responseData = error?.response?.data;
-  logger.error(`${message}: ${errorDetail}`);
-  if (responseData) logger.error(`Simplybook response body: ${JSON.stringify(responseData)}`);
+  const status = error?.response?.status;
+  // Don't log error.response.data — booking responses contain client emails and other PII.
+  // The caller's message already includes the bookingId/bookingCode to identify the record.
+  logger.error(`${message}: ${errorDetail}${status ? ` (status ${status})` : ''}`);
   throw new Error(`${message}: ${errorDetail}`);
 };

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -96,6 +96,18 @@ export class Logger extends ConsoleLogger {
         captureUncaught: true,
         captureUnhandledRejections: true,
         captureIp: 'anonymize',
+        // Rollbar replaces (does not merge with) its default scrubFields when this option is set,
+        // so include the standard list and add 'token' to also mask the Simplybook webhook URL param.
+        scrubFields: [
+          'passwd',
+          'password',
+          'secret',
+          'confirm_password',
+          'password_confirmation',
+          'auth',
+          'authentication',
+          'token',
+        ],
         ignoredMessages: [...Object.values(FIREBASE_ERRORS)],
       });
     }

--- a/src/partner-access/dtos/simplybook-body.dto.ts
+++ b/src/partner-access/dtos/simplybook-body.dto.ts
@@ -15,7 +15,7 @@ export class SimplybookBodyDto {
   client_email: string;
 
   @SecureInput('text', { required: false, maxLength: 100 })
-  @ApiProperty({ type: String })
+  @ApiProperty({ type: String, required: false })
   user_id?: string;
 
   @IsOptional()
@@ -24,8 +24,8 @@ export class SimplybookBodyDto {
   booking_id?: number;
 
   @SecureInput('text', { required: false, maxLength: 50 })
-  @ApiProperty({ type: String })
-  client_timezone: string;
+  @ApiProperty({ type: String, required: false })
+  client_timezone?: string;
 
   @SecureInput('text', { required: true, maxLength: 100 })
   @IsDefined()

--- a/src/partner-access/dtos/simplybook-body.dto.ts
+++ b/src/partner-access/dtos/simplybook-body.dto.ts
@@ -1,9 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDefined, IsEnum } from 'class-validator';
+import { IsDefined, IsEnum, IsInt, IsOptional } from 'class-validator';
 import { SIMPLYBOOK_ACTION_ENUM } from '../../utils/constants';
 import { SecureInput } from '../../utils/sanitization.decorators';
 
-export class ZapierSimplybookBodyDto {
+export class SimplybookBodyDto {
   @IsEnum(SIMPLYBOOK_ACTION_ENUM)
   @IsDefined()
   @ApiProperty({ type: String })
@@ -17,6 +17,11 @@ export class ZapierSimplybookBodyDto {
   @SecureInput('text', { required: false, maxLength: 100 })
   @ApiProperty({ type: String })
   user_id?: string;
+
+  @IsOptional()
+  @IsInt()
+  @ApiProperty({ type: Number, required: false })
+  booking_id?: number;
 
   @SecureInput('text', { required: false, maxLength: 50 })
   @ApiProperty({ type: String })

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -173,6 +173,16 @@ export const FRONT_CHAT_ATTACHMENT_ALLOWED_MIME_TYPES = new Set([
 ]);
 export const FRONT_CHAT_ATTACHMENT_MAX_FILE_SIZE = 25 * 1024 * 1024; // 25 MB
 
+export const simplybookWebhookSecret = getEnv(
+  process.env.SIMPLYBOOK_WEBHOOK_SECRET,
+  'SIMPLYBOOK_WEBHOOK_SECRET',
+);
+
+export const simplybookTotpSecret = getEnv(
+  process.env.SIMPLYBOOK_TOTP_SECRET,
+  'SIMPLYBOOK_TOTP_SECRET',
+);
+
 export const slackWebhookUrl = getEnv(process.env.SLACK_WEBHOOK_URL, 'SLACK_WEBHOOK_URL');
 export const slackBloomUsersWebhookUrl = getEnv(
   process.env.SLACK_BLOOM_USERS_WEBHOOK_URL,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -177,6 +177,12 @@ export const simplybookWebhookSecret = getEnv(
   process.env.SIMPLYBOOK_WEBHOOK_SECRET,
   'SIMPLYBOOK_WEBHOOK_SECRET',
 );
+// Fail fast in production rather than silently rejecting every Simplybook webhook
+// with a 401. SIMPLYBOOK_TOTP_SECRET is intentionally not required at startup because
+// it's only needed when 2FA is enabled on the Simplybook account.
+if (isProduction && !simplybookWebhookSecret) {
+  throw new Error('SIMPLYBOOK_WEBHOOK_SECRET is required in production');
+}
 
 export const simplybookTotpSecret = getEnv(
   process.env.SIMPLYBOOK_TOTP_SECRET,

--- a/src/utils/serialize.spec.ts
+++ b/src/utils/serialize.spec.ts
@@ -1,10 +1,10 @@
 import { mockPartnerAccessEntity, mockSimplybookBodyBase } from 'test/utils/mockData';
-import { serializeZapierSimplyBookDtoToTherapySessionEntity } from './serialize';
+import { serializeSimplybookDtoToTherapySessionEntity } from './serialize';
 
 describe('Serialize', () => {
-  describe('serializeZapierSimplyBookDtoToTherapySessionEntity', () => {
+  describe('serializeSimplybookDtoToTherapySessionEntity', () => {
     it('should format object correctly when valid object is supplied', () => {
-      const randomString = serializeZapierSimplyBookDtoToTherapySessionEntity(
+      const randomString = serializeSimplybookDtoToTherapySessionEntity(
         mockSimplybookBodyBase,
         mockPartnerAccessEntity,
       );

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -9,7 +9,7 @@ import { PartnerAccessEntity } from '../entities/partner-access.entity';
 import { SubscriptionUserEntity } from '../entities/subscription-user.entity';
 import { TherapySessionEntity } from '../entities/therapy-session.entity';
 import { UserEntity } from '../entities/user.entity';
-import { ZapierSimplybookBodyDto } from '../partner-access/dtos/zapier-body.dto';
+import { SimplybookBodyDto } from '../partner-access/dtos/simplybook-body.dto';
 import { ISubscriptionUser } from '../subscription-user/subscription-user.interface';
 import { GetTherapySessionDto } from '../therapy-session/dto/get-therapy-session.dto';
 import { GetUserDto } from '../user/dtos/get-user.dto';
@@ -151,13 +151,14 @@ export const formatPartnerObject = (partnerObject: PartnerEntity): IPartner => {
   };
 };
 
-export const serializeZapierSimplyBookDtoToTherapySessionEntity = (
-  therapySession: ZapierSimplybookBodyDto,
+export const serializeSimplybookDtoToTherapySessionEntity = (
+  therapySession: SimplybookBodyDto,
   partnerAccess: PartnerAccessEntity,
 ): Partial<TherapySessionEntity> => {
   return {
     action: therapySession.action,
     bookingCode: therapySession.booking_code,
+    ...(therapySession.booking_id !== undefined && { bookingId: therapySession.booking_id }),
     clientEmail: therapySession.client_email,
     clientTimezone: therapySession.client_timezone,
     serviceName: therapySession.service_name,

--- a/src/webhooks/dto/simplybook-webhook.dto.ts
+++ b/src/webhooks/dto/simplybook-webhook.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsDefined, IsEnum, IsInt, IsString } from 'class-validator';
+import { IsDefined, IsEnum, IsInt, IsOptional, IsString } from 'class-validator';
 
 export enum SimplybookNotificationType {
   CREATE = 'create',
@@ -25,4 +25,14 @@ export class SimplybookWebhookDto {
   @IsDefined()
   @ApiProperty({ enum: SimplybookNotificationType })
   notification_type: SimplybookNotificationType;
+
+  // Unix timestamp (seconds) when Simplybook generated the webhook. Used to reject
+  // replayed webhooks if a leaked URL token is used to re-submit captured payloads.
+  // Optional so we don't break if Simplybook ever omits it; presence is enforced in
+  // the service layer with a clear log message instead.
+  @IsOptional()
+  @IsInt()
+  @Type(() => Number)
+  @ApiProperty({ type: Number, required: false })
+  webhook_timestamp?: number;
 }

--- a/src/webhooks/dto/simplybook-webhook.dto.ts
+++ b/src/webhooks/dto/simplybook-webhook.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsDefined, IsEnum, IsInt, IsString, Matches } from 'class-validator';
+import { IsDefined, IsEnum, IsInt, IsString } from 'class-validator';
 
 export enum SimplybookNotificationType {
   CREATE = 'create',
@@ -15,12 +15,6 @@ export class SimplybookWebhookDto {
   @IsDefined()
   @ApiProperty({ type: Number })
   booking_id: number;
-
-  @IsString()
-  @Matches(/^[a-f0-9]+$/, { message: 'booking_hash must be a hex string' })
-  @IsDefined()
-  @ApiProperty({ type: String })
-  booking_hash: string;
 
   @IsString()
   @IsDefined()

--- a/src/webhooks/dtos/simplybook-webhook.dto.ts
+++ b/src/webhooks/dtos/simplybook-webhook.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsDefined, IsEnum, IsInt, IsString, Matches } from 'class-validator';
+
+export enum SimplybookNotificationType {
+  CREATE = 'create',
+  CANCEL = 'cancel',
+  CHANGE = 'change',
+  NOTIFY = 'notify',
+}
+
+export class SimplybookWebhookDto {
+  @IsInt()
+  @Type(() => Number)
+  @IsDefined()
+  @ApiProperty({ type: Number })
+  booking_id: number;
+
+  @IsString()
+  @Matches(/^[a-f0-9]+$/, { message: 'booking_hash must be a hex string' })
+  @IsDefined()
+  @ApiProperty({ type: String })
+  booking_hash: string;
+
+  @IsString()
+  @IsDefined()
+  @ApiProperty({ type: String })
+  company: string;
+
+  @IsEnum(SimplybookNotificationType)
+  @IsDefined()
+  @ApiProperty({ enum: SimplybookNotificationType })
+  notification_type: SimplybookNotificationType;
+}

--- a/src/webhooks/guards/simplybook-webhook.guard.spec.ts
+++ b/src/webhooks/guards/simplybook-webhook.guard.spec.ts
@@ -1,0 +1,48 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+
+jest.mock('src/utils/constants', () => {
+  const actual = jest.requireActual('src/utils/constants');
+  return {
+    ...actual,
+    simplybookWebhookSecret: 'test-secret-value',
+  };
+});
+
+import { SimplybookWebhookGuard } from './simplybook-webhook.guard';
+
+const buildContext = (query: Record<string, unknown>): ExecutionContext =>
+  ({
+    switchToHttp: () => ({
+      getRequest: () => ({ query }),
+    }),
+  }) as unknown as ExecutionContext;
+
+describe('SimplybookWebhookGuard', () => {
+  const guard = new SimplybookWebhookGuard();
+
+  it('allows a request with the correct token', () => {
+    expect(guard.canActivate(buildContext({ token: 'test-secret-value' }))).toBe(true);
+  });
+
+  it('rejects a request with no token', () => {
+    expect(() => guard.canActivate(buildContext({}))).toThrow(UnauthorizedException);
+  });
+
+  it('rejects a request with the wrong token of the same length', () => {
+    expect(() => guard.canActivate(buildContext({ token: 'wrong-secret-value' }))).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('rejects a request with a token of different length', () => {
+    expect(() => guard.canActivate(buildContext({ token: 'short' }))).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('rejects a request when token is an array (duplicate query params)', () => {
+    expect(() =>
+      guard.canActivate(buildContext({ token: ['test-secret-value', 'extra'] })),
+    ).toThrow(UnauthorizedException);
+  });
+});

--- a/src/webhooks/guards/simplybook-webhook.guard.ts
+++ b/src/webhooks/guards/simplybook-webhook.guard.ts
@@ -1,0 +1,19 @@
+import { CanActivate, ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { timingSafeEqual } from 'crypto';
+import { Request } from 'express';
+import { simplybookWebhookSecret } from 'src/utils/constants';
+
+export class SimplybookWebhookGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request>();
+    const providedToken = (request.query.token as string) || '';
+    const expected = Buffer.from(simplybookWebhookSecret || '');
+    const provided = Buffer.from(providedToken);
+
+    if (!expected.length || expected.length !== provided.length || !timingSafeEqual(expected, provided)) {
+      throw new UnauthorizedException('Unauthorized: invalid webhook token');
+    }
+
+    return true;
+  }
+}

--- a/src/webhooks/guards/simplybook-webhook.guard.ts
+++ b/src/webhooks/guards/simplybook-webhook.guard.ts
@@ -6,11 +6,17 @@ import { simplybookWebhookSecret } from 'src/utils/constants';
 export class SimplybookWebhookGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
     const request = context.switchToHttp().getRequest<Request>();
-    const providedToken = (request.query.token as string) || '';
+    const rawToken = request.query.token;
+    // Reject anything that isn't a single string (e.g. ?token=a&token=b parses as an array)
+    const providedToken = typeof rawToken === 'string' ? rawToken : '';
     const expected = Buffer.from(simplybookWebhookSecret || '');
     const provided = Buffer.from(providedToken);
 
-    if (!expected.length || expected.length !== provided.length || !timingSafeEqual(expected, provided)) {
+    if (
+      !expected.length ||
+      expected.length !== provided.length ||
+      !timingSafeEqual(expected, provided)
+    ) {
       throw new UnauthorizedException('Unauthorized: invalid webhook token');
     }
 

--- a/src/webhooks/webhooks.controller.spec.ts
+++ b/src/webhooks/webhooks.controller.spec.ts
@@ -2,8 +2,15 @@ import { createMock } from '@golevelup/ts-jest';
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { FrontChatWebhookService } from 'src/front-chat/front-chat-webhook.service';
-import { mockSessionEntity, mockSimplybookBodyBase, mockStoryWebhookDto, mockTherapySessionEntity } from 'test/utils/mockData';
+import {
+  mockSessionEntity,
+  mockSimplybookBodyBase,
+  mockSimplybookWebhookDto,
+  mockStoryWebhookDto,
+  mockTherapySessionEntity,
+} from 'test/utils/mockData';
 import { mockWebhooksServiceMethods } from 'test/utils/mockedServices';
+import { SimplybookNotificationType } from './dtos/simplybook-webhook.dto';
 import { WebhooksController } from './webhooks.controller';
 import { WebhooksService } from './webhooks.service';
 
@@ -42,6 +49,32 @@ describe('AppController', () => {
       ).rejects.toThrow('Therapy session not found');
     });
 
+    describe('handleSimplybookWebhook', () => {
+      it('should return therapy session when service succeeds', async () => {
+        await expect(
+          webhooksController.handleSimplybookWebhook(mockSimplybookWebhookDto, 'test-token'),
+        ).resolves.toBe(mockTherapySessionEntity);
+      });
+
+      it('should return undefined for notify type', async () => {
+        jest.spyOn(mockWebhooksService, 'handleSimplybookWebhook').mockResolvedValueOnce(undefined);
+        await expect(
+          webhooksController.handleSimplybookWebhook(
+            { ...mockSimplybookWebhookDto, notification_type: SimplybookNotificationType.NOTIFY },
+            'test-token',
+          ),
+        ).resolves.toBeUndefined();
+      });
+
+      it('should propagate errors from service', async () => {
+        jest
+          .spyOn(mockWebhooksService, 'handleSimplybookWebhook')
+          .mockRejectedValueOnce(new HttpException('Booking not found', HttpStatus.BAD_REQUEST));
+        await expect(
+          webhooksController.handleSimplybookWebhook(mockSimplybookWebhookDto, 'test-token'),
+        ).rejects.toThrow('Booking not found');
+      });
+    });
     describe('handleStoryUpdated', () => {
       it('delegates to webhooksService.handleStoryblokWebhook with rawBody and signature', async () => {
         jest

--- a/src/webhooks/webhooks.controller.spec.ts
+++ b/src/webhooks/webhooks.controller.spec.ts
@@ -10,7 +10,7 @@ import {
   mockTherapySessionEntity,
 } from 'test/utils/mockData';
 import { mockWebhooksServiceMethods } from 'test/utils/mockedServices';
-import { SimplybookNotificationType } from './dtos/simplybook-webhook.dto';
+import { SimplybookNotificationType } from './dto/simplybook-webhook.dto';
 import { WebhooksController } from './webhooks.controller';
 import { WebhooksService } from './webhooks.service';
 
@@ -52,17 +52,17 @@ describe('AppController', () => {
     describe('handleSimplybookWebhook', () => {
       it('should return therapy session when service succeeds', async () => {
         await expect(
-          webhooksController.handleSimplybookWebhook(mockSimplybookWebhookDto, 'test-token'),
+          webhooksController.handleSimplybookWebhook(mockSimplybookWebhookDto),
         ).resolves.toBe(mockTherapySessionEntity);
       });
 
       it('should return undefined for notify type', async () => {
         jest.spyOn(mockWebhooksService, 'handleSimplybookWebhook').mockResolvedValueOnce(undefined);
         await expect(
-          webhooksController.handleSimplybookWebhook(
-            { ...mockSimplybookWebhookDto, notification_type: SimplybookNotificationType.NOTIFY },
-            'test-token',
-          ),
+          webhooksController.handleSimplybookWebhook({
+            ...mockSimplybookWebhookDto,
+            notification_type: SimplybookNotificationType.NOTIFY,
+          }),
         ).resolves.toBeUndefined();
       });
 
@@ -71,7 +71,7 @@ describe('AppController', () => {
           .spyOn(mockWebhooksService, 'handleSimplybookWebhook')
           .mockRejectedValueOnce(new HttpException('Booking not found', HttpStatus.BAD_REQUEST));
         await expect(
-          webhooksController.handleSimplybookWebhook(mockSimplybookWebhookDto, 'test-token'),
+          webhooksController.handleSimplybookWebhook(mockSimplybookWebhookDto),
         ).rejects.toThrow('Booking not found');
       });
     });

--- a/src/webhooks/webhooks.controller.ts
+++ b/src/webhooks/webhooks.controller.ts
@@ -1,12 +1,14 @@
-import { Body, Controller, Headers, Post, Request, UseGuards } from '@nestjs/common';
-import { ApiBody, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Headers, Post, Query, Request, UseGuards } from '@nestjs/common';
+import { ApiBody, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
 import { FrontChatWebhookService } from 'src/front-chat/front-chat-webhook.service';
 import { ControllerDecorator } from 'src/utils/controller.decorator';
-import { ZapierSimplybookBodyDto } from '../partner-access/dtos/zapier-body.dto';
+import { SimplybookBodyDto } from '../partner-access/dtos/simplybook-body.dto';
 import { ZapierAuthGuard } from '../partner-access/zapier-auth.guard';
 import { FrontChatWebhookDto } from './dto/front-chat-webhook.dto';
 import { StoryWebhookDto } from './dto/story.dto';
+import { SimplybookWebhookDto } from './dtos/simplybook-webhook.dto';
+import { SimplybookWebhookGuard } from './guards/simplybook-webhook.guard';
 import { WebhooksService } from './webhooks.service';
 
 @ApiTags('Webhooks')
@@ -20,11 +22,22 @@ export class WebhooksController {
 
   @UseGuards(ZapierAuthGuard)
   @Post('simplybook')
-  @ApiBody({ type: ZapierSimplybookBodyDto })
+  @ApiBody({ type: SimplybookBodyDto })
   async updatePartnerAccessTherapy(
-    @Body() simplybookBodyDto: ZapierSimplybookBodyDto,
+    @Body() simplybookBodyDto: SimplybookBodyDto,
   ): Promise<TherapySessionEntity> {
     return this.webhooksService.updatePartnerAccessTherapy(simplybookBodyDto);
+  }
+
+  @UseGuards(SimplybookWebhookGuard)
+  @Post('simplybook-admin')
+  @ApiBody({ type: SimplybookWebhookDto })
+  @ApiQuery({ name: 'token', required: true, description: 'Webhook secret token' })
+  async handleSimplybookWebhook(
+    @Body() webhookDto: SimplybookWebhookDto,
+    @Query('token') _token: string,
+  ): Promise<TherapySessionEntity | void> {
+    return this.webhooksService.handleSimplybookWebhook(webhookDto);
   }
 
   @Post('storyblok')

--- a/src/webhooks/webhooks.controller.ts
+++ b/src/webhooks/webhooks.controller.ts
@@ -1,13 +1,14 @@
-import { Body, Controller, Headers, Post, Query, Request, UseGuards } from '@nestjs/common';
+import { Body, Controller, Headers, Post, Request, UseGuards } from '@nestjs/common';
 import { ApiBody, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
 import { FrontChatWebhookService } from 'src/front-chat/front-chat-webhook.service';
 import { ControllerDecorator } from 'src/utils/controller.decorator';
 import { SimplybookBodyDto } from '../partner-access/dtos/simplybook-body.dto';
 import { ZapierAuthGuard } from '../partner-access/zapier-auth.guard';
 import { FrontChatWebhookDto } from './dto/front-chat-webhook.dto';
+import { SimplybookWebhookDto } from './dto/simplybook-webhook.dto';
 import { StoryWebhookDto } from './dto/story.dto';
-import { SimplybookWebhookDto } from './dtos/simplybook-webhook.dto';
 import { SimplybookWebhookGuard } from './guards/simplybook-webhook.guard';
 import { WebhooksService } from './webhooks.service';
 
@@ -29,13 +30,16 @@ export class WebhooksController {
     return this.webhooksService.updatePartnerAccessTherapy(simplybookBodyDto);
   }
 
+  // Tight rate limit: real Simplybook traffic is a handful of events/minute at peak.
+  // 30/min leaves headroom for burst deliveries (e.g. backfills) while deterring brute-force
+  // attempts to guess the token in the URL.
+  @Throttle({ default: { limit: 30, ttl: 60000 } })
   @UseGuards(SimplybookWebhookGuard)
   @Post('simplybook-admin')
   @ApiBody({ type: SimplybookWebhookDto })
   @ApiQuery({ name: 'token', required: true, description: 'Webhook secret token' })
   async handleSimplybookWebhook(
     @Body() webhookDto: SimplybookWebhookDto,
-    @Query('token') _token: string,
   ): Promise<TherapySessionEntity | void> {
     return this.webhooksService.handleSimplybookWebhook(webhookDto);
   }

--- a/src/webhooks/webhooks.service.spec.ts
+++ b/src/webhooks/webhooks.service.spec.ts
@@ -2,6 +2,7 @@ import { createMock } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import apiCall from 'src/api/apiCalls';
+import * as simplybookApi from 'src/api/simplybook/simplybook-api';
 import { SlackMessageClient } from 'src/api/slack/slack-api';
 import { CoursePartnerService } from 'src/course-partner/course-partner.service';
 import { CoursePartnerEntity } from 'src/entities/course-partner.entity';
@@ -30,6 +31,8 @@ import {
   mockSession,
   mockSessionStoryblokResult,
   mockSimplybookBodyBase,
+  mockSimplybookBookingDetails,
+  mockSimplybookWebhookDto,
   mockTherapySessionEntity,
   mockUserEntity,
 } from 'test/utils/mockData';
@@ -47,6 +50,7 @@ import {
   mockUserRepositoryMethods,
 } from 'test/utils/mockedServices';
 import { ILike, Repository } from 'typeorm';
+import { SimplybookNotificationType } from './dtos/simplybook-webhook.dto';
 import { WebhooksService } from './webhooks.service';
 
 jest.mock('src/api/apiCalls');
@@ -61,16 +65,24 @@ jest.mock('src/utils/constants', () => {
 
 jest.mock('src/api/simplybook/simplybook-api', () => {
   return {
-    getBookingsForDate: async () => [
+    getBookingsForDate: jest.fn(async () => [
       {
         bookingCode: 'bookingCodeA',
         clientEmail: 'ellie@chayn.co',
         date: new Date(2022, 9, 10),
       },
-    ],
-    getAuthToken: async () => {
-      return 'token';
-    },
+    ]),
+    getAuthToken: jest.fn(async () => 'token'),
+    getBookingDetails: jest.fn(async () => ({
+      id: 123,
+      code: 'abc',
+      start_datetime: '2022-09-12T07:30:00+0000',
+      end_datetime: '2022-09-12T08:30:00+0000',
+      service: { name: 'bloom therapy' },
+      provider: { name: 'Therapist name', email: 'therapist@test.com' },
+      client: { email: 'testuser@test.com' },
+      additional_fields: [{ id: 1, field_name: 'user_id', value: 'userId2' }],
+    })),
   };
 });
 
@@ -828,4 +840,71 @@ describe('WebhooksService', () => {
     });
   });
 
+  describe('handleSimplybookWebhook', () => {
+    let getBookingDetailsSpy: jest.SpyInstance;
+    let updateTherapySpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      getBookingDetailsSpy = jest.spyOn(simplybookApi, 'getBookingDetails');
+      updateTherapySpy = jest
+        .spyOn(service, 'updatePartnerAccessTherapy')
+        .mockResolvedValue(mockTherapySessionEntity);
+    });
+
+    it('should return undefined and not call Simplybook API for notify type', async () => {
+      const result = await service.handleSimplybookWebhook({
+        ...mockSimplybookWebhookDto,
+        notification_type: SimplybookNotificationType.NOTIFY,
+      });
+      expect(result).toBeUndefined();
+      expect(getBookingDetailsSpy).not.toHaveBeenCalled();
+    });
+
+    it('should fetch booking details and map create to NEW_BOOKING', async () => {
+      await service.handleSimplybookWebhook({
+        ...mockSimplybookWebhookDto,
+        notification_type: SimplybookNotificationType.CREATE,
+      });
+      expect(getBookingDetailsSpy).toHaveBeenCalledWith(mockSimplybookWebhookDto.booking_id);
+      expect(updateTherapySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: SIMPLYBOOK_ACTION_ENUM.NEW_BOOKING,
+          booking_code: 'abc',
+          client_email: 'testuser@test.com',
+          user_id: 'userId2',
+        }),
+      );
+    });
+
+    it('should map cancel to CANCELLED_BOOKING', async () => {
+      await service.handleSimplybookWebhook({
+        ...mockSimplybookWebhookDto,
+        notification_type: SimplybookNotificationType.CANCEL,
+      });
+      expect(updateTherapySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ action: SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING }),
+      );
+    });
+
+    it('should map change to UPDATED_BOOKING', async () => {
+      await service.handleSimplybookWebhook({
+        ...mockSimplybookWebhookDto,
+        notification_type: SimplybookNotificationType.CHANGE,
+      });
+      expect(updateTherapySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ action: SIMPLYBOOK_ACTION_ENUM.UPDATED_BOOKING }),
+      );
+    });
+
+    it('should pass undefined user_id when not present in additional_fields', async () => {
+      getBookingDetailsSpy.mockResolvedValueOnce({
+        ...mockSimplybookBookingDetails,
+        additional_fields: [],
+      });
+      await service.handleSimplybookWebhook(mockSimplybookWebhookDto);
+      expect(updateTherapySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ user_id: undefined }),
+      );
+    });
+  });
 });

--- a/src/webhooks/webhooks.service.spec.ts
+++ b/src/webhooks/webhooks.service.spec.ts
@@ -709,34 +709,40 @@ describe('WebhooksService', () => {
       ).resolves.toHaveProperty('action', SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING);
     });
 
-    it('should add therapyRemaining to original partner access when action is cancel', async () => {
-      const partnerAccessSaveSpy = jest.spyOn(mockedPartnerAccessRepository, 'save');
+    it('should credit therapyRemaining back to original partner access when action is cancel', async () => {
+      const incrementSpy = jest.spyOn(mockedPartnerAccessRepository, 'increment');
+      const decrementSpy = jest.spyOn(mockedPartnerAccessRepository, 'decrement');
       await expect(
         service.updatePartnerAccessTherapy({
           ...mockSimplybookBodyBase,
           ...{ action: SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING },
         }),
       ).resolves.toHaveProperty('action', SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING);
-      expect(partnerAccessSaveSpy).toHaveBeenCalledWith({
-        ...mockPartnerAccessEntity,
-        therapySessionsRemaining: mockPartnerAccessEntity.therapySessionsRemaining + 1,
-        therapySessionsRedeemed: mockPartnerAccessEntity.therapySessionsRedeemed - 1,
-      });
+      expect(incrementSpy).toHaveBeenCalledWith(
+        { id: mockTherapySessionEntity.partnerAccessId },
+        'therapySessionsRemaining',
+        1,
+      );
+      expect(decrementSpy).toHaveBeenCalledWith(
+        { id: mockTherapySessionEntity.partnerAccessId },
+        'therapySessionsRedeemed',
+        1,
+      );
     });
 
-    it('should set a booking as cancelled when action is cancel and there are no therapy sessions remaining TODO', async () => {
-      const partnerAccessFindSpy = jest
-        .spyOn(mockedPartnerAccessRepository, 'findOneBy')
-        .mockImplementationOnce(async () => {
-          return { ...mockPartnerAccessEntity, therapySessionsRemaining: 0 };
-        });
+    it('should still credit back when partner access has zero remaining (cancel path uses atomic increment)', async () => {
+      const incrementSpy = jest.spyOn(mockedPartnerAccessRepository, 'increment');
       await expect(
         service.updatePartnerAccessTherapy({
           ...mockSimplybookBodyBase,
           ...{ action: SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING },
         }),
       ).resolves.toHaveProperty('action', SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING);
-      expect(partnerAccessFindSpy).toHaveBeenCalled();
+      expect(incrementSpy).toHaveBeenCalledWith(
+        { id: mockTherapySessionEntity.partnerAccessId },
+        'therapySessionsRemaining',
+        1,
+      );
     });
 
     it('should throw if no partnerAccess exists when user tries to create a booking', async () => {
@@ -758,25 +764,37 @@ describe('WebhooksService', () => {
         ];
       });
 
-      const partnerAccessSaveSpy = jest.spyOn(mockedPartnerAccessRepository, 'save');
+      const decrementSpy = jest.spyOn(mockedPartnerAccessRepository, 'decrement');
+      const incrementSpy = jest.spyOn(mockedPartnerAccessRepository, 'increment');
       await expect(
         service.updatePartnerAccessTherapy({
           ...mockSimplybookBodyBase,
           ...{ action: SIMPLYBOOK_ACTION_ENUM.NEW_BOOKING },
         }),
       ).resolves.toHaveProperty('action', SIMPLYBOOK_ACTION_ENUM.NEW_BOOKING);
-      expect(partnerAccessSaveSpy).toHaveBeenCalledWith(mockPartnerAccessEntity);
+      expect(decrementSpy).toHaveBeenCalledWith(
+        { id: mockPartnerAccessEntity.id },
+        'therapySessionsRemaining',
+        1,
+      );
+      expect(incrementSpy).toHaveBeenCalledWith(
+        { id: mockPartnerAccessEntity.id },
+        'therapySessionsRedeemed',
+        1,
+      );
     });
 
-    it('should not update partner access when user updates booking', async () => {
-      const partnerAccessSaveSpy = jest.spyOn(mockedPartnerAccessRepository, 'save');
+    it('should not increment/decrement partner access counters when user updates booking', async () => {
+      const incrementSpy = jest.spyOn(mockedPartnerAccessRepository, 'increment');
+      const decrementSpy = jest.spyOn(mockedPartnerAccessRepository, 'decrement');
       await expect(
         service.updatePartnerAccessTherapy({
           ...mockSimplybookBodyBase,
           ...{ action: SIMPLYBOOK_ACTION_ENUM.UPDATED_BOOKING },
         }),
       ).resolves.toHaveProperty('action', SIMPLYBOOK_ACTION_ENUM.UPDATED_BOOKING);
-      expect(partnerAccessSaveSpy).not.toHaveBeenCalled();
+      expect(incrementSpy).not.toHaveBeenCalled();
+      expect(decrementSpy).not.toHaveBeenCalled();
     });
     it('should error if user creates booking when no therapy sessions remaining ', async () => {
       jest.spyOn(mockedPartnerAccessRepository, 'find').mockImplementationOnce(async () => {

--- a/src/webhooks/webhooks.service.spec.ts
+++ b/src/webhooks/webhooks.service.spec.ts
@@ -50,7 +50,7 @@ import {
   mockUserRepositoryMethods,
 } from 'test/utils/mockedServices';
 import { ILike, Repository } from 'typeorm';
-import { SimplybookNotificationType } from './dtos/simplybook-webhook.dto';
+import { SimplybookNotificationType } from './dto/simplybook-webhook.dto';
 import { WebhooksService } from './webhooks.service';
 
 jest.mock('src/api/apiCalls');
@@ -60,19 +60,12 @@ jest.mock('src/utils/constants', () => {
   return {
     ...actual,
     storyblokToken: 'test-storyblok-token',
+    simplybookCompanyName: 'chayn',
   };
 });
 
 jest.mock('src/api/simplybook/simplybook-api', () => {
   return {
-    getBookingsForDate: jest.fn(async () => [
-      {
-        bookingCode: 'bookingCodeA',
-        clientEmail: 'ellie@chayn.co',
-        date: new Date(2022, 9, 10),
-      },
-    ]),
-    getAuthToken: jest.fn(async () => 'token'),
     getBookingDetails: jest.fn(async () => ({
       id: 123,
       code: 'abc',
@@ -905,6 +898,16 @@ describe('WebhooksService', () => {
       expect(updateTherapySpy).toHaveBeenCalledWith(
         expect.objectContaining({ user_id: undefined }),
       );
+    });
+
+    it('should reject when company does not match', async () => {
+      await expect(
+        service.handleSimplybookWebhook({
+          ...mockSimplybookWebhookDto,
+          company: 'someone-else',
+        }),
+      ).rejects.toThrow(/unexpected company/);
+      expect(getBookingDetailsSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/webhooks/webhooks.service.ts
+++ b/src/webhooks/webhooks.service.ts
@@ -22,13 +22,14 @@ import {
   isProduction,
   RESOURCE_CATEGORIES,
   SIMPLYBOOK_ACTION_ENUM,
+  simplybookCompanyName,
   STORYBLOK_PAGE_COMPONENTS,
   STORYBLOK_STORY_STATUS_ENUM,
   storyblokToken,
   storyblokWebhookSecret,
 } from '../utils/constants';
+import { SimplybookNotificationType, SimplybookWebhookDto } from './dto/simplybook-webhook.dto';
 import { StoryWebhookDto } from './dto/story.dto';
-import { SimplybookNotificationType, SimplybookWebhookDto } from './dtos/simplybook-webhook.dto';
 
 @Injectable()
 export class WebhooksService {
@@ -91,8 +92,25 @@ export class WebhooksService {
     // Updating an existing therapy session
     existingTherapySession.action = action;
 
-    // If the booking is cancelled, increment the therapy sessions remaining on related partner access
-    if (action === SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING) {
+    // Reconcile bookingId. The lookup uses clientEmail + bookingCode, so a mismatched
+    // bookingId means we matched the wrong record (or Simplybook reused a code) — bail
+    // out rather than silently overwrite and risk corrupting accounting.
+    if (simplyBookDto.booking_id !== undefined) {
+      if (existingTherapySession.bookingId == null) {
+        existingTherapySession.bookingId = simplyBookDto.booking_id;
+      } else if (existingTherapySession.bookingId !== simplyBookDto.booking_id) {
+        const error = `UpdatePartnerAccessTherapy - bookingId mismatch for booking_code ${booking_code}: existing ${existingTherapySession.bookingId}, incoming ${simplyBookDto.booking_id}`;
+        this.logger.error(error);
+        throw new HttpException(error, HttpStatus.CONFLICT);
+      }
+    }
+
+    // If the booking is cancelled, increment the therapy sessions remaining on related partner access.
+    // Guard against duplicate webhook deliveries: only credit the session back once.
+    if (
+      action === SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING &&
+      !existingTherapySession.cancelledAt
+    ) {
       try {
         const partnerAccess = await this.partnerAccessRepository.findOneBy({
           id: existingTherapySession.partnerAccessId,
@@ -147,6 +165,12 @@ export class WebhooksService {
   async handleSimplybookWebhook(
     webhookDto: SimplybookWebhookDto,
   ): Promise<TherapySessionEntity | void> {
+    if (webhookDto.company !== simplybookCompanyName) {
+      const error = `Simplybook webhook received for unexpected company ${webhookDto.company}`;
+      this.logger.error(error);
+      throw new HttpException(error, HttpStatus.UNAUTHORIZED);
+    }
+
     if (webhookDto.notification_type === SimplybookNotificationType.NOTIFY) {
       this.logger.log(
         `Simplybook reminder webhook received for booking ${webhookDto.booking_id} - ignoring`,
@@ -154,7 +178,10 @@ export class WebhooksService {
       return;
     }
 
-    const notificationTypeToAction: Record<string, SIMPLYBOOK_ACTION_ENUM> = {
+    const notificationTypeToAction: Record<
+      Exclude<SimplybookNotificationType, SimplybookNotificationType.NOTIFY>,
+      SIMPLYBOOK_ACTION_ENUM
+    > = {
       [SimplybookNotificationType.CREATE]: SIMPLYBOOK_ACTION_ENUM.NEW_BOOKING,
       [SimplybookNotificationType.CANCEL]: SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING,
       [SimplybookNotificationType.CHANGE]: SIMPLYBOOK_ACTION_ENUM.UPDATED_BOOKING,
@@ -163,18 +190,9 @@ export class WebhooksService {
     const action = notificationTypeToAction[webhookDto.notification_type];
     const bookingDetails = await getBookingDetails(webhookDto.booking_id);
 
-    // NOTE: user_id pre-fill is currently broken on the frontend.
-    // The user_id intake field is set to "not visible" in Simplybook admin, which causes
-    // Simplybook to drop it from the form submission — the predefined value is never passed
-    // through to the booking payload, so userId will always be undefined here.
-    //
-    // The fallback in updatePartnerAccessTherapy handles this: it looks up the user by
-    // client_email, which Simplybook always submits and the frontend pre-fills reliably.
-    //
-    // Possible fixes (tracked on the frontend):
-    // 1. Make the user_id field visible in Simplybook admin — fixes it but exposes a raw UUID.
-    // 2. Pre-fill with the user's active therapy access code instead — less confusing to users,
-    //    but needs a reliable way to select one code when a user has multiple active ones.
+    // user_id is sourced from a Simplybook intake field. It is currently unset in production
+    // because the field is "not visible" in admin, so Simplybook drops it from submissions.
+    // updatePartnerAccessTherapy falls back to client_email lookup when userId is undefined.
     const userId =
       bookingDetails.additional_fields.find((f) => f.field_name === 'user_id')?.value || undefined;
 
@@ -183,14 +201,13 @@ export class WebhooksService {
       booking_id: webhookDto.booking_id,
       booking_code: bookingDetails.code,
       client_email: bookingDetails.client.email,
-      client_timezone: undefined,
       service_name: bookingDetails.service.name,
       service_provider_name: bookingDetails.provider.name,
       service_provider_email: bookingDetails.provider.email,
       start_date_time: bookingDetails.start_datetime,
       end_date_time: bookingDetails.end_datetime,
       user_id: userId,
-    } as SimplybookBodyDto;
+    };
 
     return this.updatePartnerAccessTherapy(internalDto);
   }

--- a/src/webhooks/webhooks.service.ts
+++ b/src/webhooks/webhooks.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { ISbStoryData } from '@storyblok/js';
 import { createHmac, timingSafeEqual } from 'crypto';
 import apiCall from 'src/api/apiCalls';
+import { getBookingDetails } from 'src/api/simplybook/simplybook-api';
 import { SlackMessageClient } from 'src/api/slack/slack-api';
 import { CourseEntity } from 'src/entities/course.entity';
 import { PartnerAccessEntity } from 'src/entities/partner-access.entity';
@@ -11,10 +12,10 @@ import { SessionEntity } from 'src/entities/session.entity';
 import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
 import { UserEntity } from 'src/entities/user.entity';
 import { Logger } from 'src/logger/logger';
-import { ZapierSimplybookBodyDto } from 'src/partner-access/dtos/zapier-body.dto';
+import { SimplybookBodyDto } from 'src/partner-access/dtos/simplybook-body.dto';
 import { ServiceUserProfilesService } from 'src/service-user-profiles/service-user-profiles.service';
 import { IUser } from 'src/user/user.interface';
-import { serializeZapierSimplyBookDtoToTherapySessionEntity } from 'src/utils/serialize';
+import { serializeSimplybookDtoToTherapySessionEntity } from 'src/utils/serialize';
 import { ILike, MoreThan, Repository } from 'typeorm';
 import { CoursePartnerService } from '../course-partner/course-partner.service';
 import {
@@ -27,6 +28,7 @@ import {
   storyblokWebhookSecret,
 } from '../utils/constants';
 import { StoryWebhookDto } from './dto/story.dto';
+import { SimplybookNotificationType, SimplybookWebhookDto } from './dtos/simplybook-webhook.dto';
 
 @Injectable()
 export class WebhooksService {
@@ -47,7 +49,7 @@ export class WebhooksService {
   ) {}
 
   async updatePartnerAccessTherapy(
-    simplyBookDto: ZapierSimplybookBodyDto,
+    simplyBookDto: SimplybookBodyDto,
   ): Promise<TherapySessionEntity> {
     const { action, booking_code, user_id, client_email } = simplyBookDto;
 
@@ -142,6 +144,57 @@ export class WebhooksService {
     }
   }
 
+  async handleSimplybookWebhook(
+    webhookDto: SimplybookWebhookDto,
+  ): Promise<TherapySessionEntity | void> {
+    if (webhookDto.notification_type === SimplybookNotificationType.NOTIFY) {
+      this.logger.log(
+        `Simplybook reminder webhook received for booking ${webhookDto.booking_id} - ignoring`,
+      );
+      return;
+    }
+
+    const notificationTypeToAction: Record<string, SIMPLYBOOK_ACTION_ENUM> = {
+      [SimplybookNotificationType.CREATE]: SIMPLYBOOK_ACTION_ENUM.NEW_BOOKING,
+      [SimplybookNotificationType.CANCEL]: SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING,
+      [SimplybookNotificationType.CHANGE]: SIMPLYBOOK_ACTION_ENUM.UPDATED_BOOKING,
+    };
+
+    const action = notificationTypeToAction[webhookDto.notification_type];
+    const bookingDetails = await getBookingDetails(webhookDto.booking_id);
+
+    // NOTE: user_id pre-fill is currently broken on the frontend.
+    // The user_id intake field is set to "not visible" in Simplybook admin, which causes
+    // Simplybook to drop it from the form submission — the predefined value is never passed
+    // through to the booking payload, so userId will always be undefined here.
+    //
+    // The fallback in updatePartnerAccessTherapy handles this: it looks up the user by
+    // client_email, which Simplybook always submits and the frontend pre-fills reliably.
+    //
+    // Possible fixes (tracked on the frontend):
+    // 1. Make the user_id field visible in Simplybook admin — fixes it but exposes a raw UUID.
+    // 2. Pre-fill with the user's active therapy access code instead — less confusing to users,
+    //    but needs a reliable way to select one code when a user has multiple active ones.
+    const userId =
+      bookingDetails.additional_fields.find((f) => f.field_name === 'user_id')?.value || undefined;
+
+    const internalDto: SimplybookBodyDto = {
+      action,
+      booking_id: webhookDto.booking_id,
+      booking_code: bookingDetails.code,
+      client_email: bookingDetails.client.email,
+      client_timezone: undefined,
+      service_name: bookingDetails.service.name,
+      service_provider_name: bookingDetails.provider.name,
+      service_provider_email: bookingDetails.provider.email,
+      start_date_time: bookingDetails.start_datetime,
+      end_date_time: bookingDetails.end_datetime,
+      user_id: userId,
+    } as SimplybookBodyDto;
+
+    return this.updatePartnerAccessTherapy(internalDto);
+  }
+
   private async getSimplyBookTherapyUser(userId: string, client_email: string): Promise<IUser> {
     if (!userId) {
       // No userId sent in the webhook - likely due to user clicking simplybook link from email instead of in-app widget
@@ -195,7 +248,7 @@ export class WebhooksService {
     }
   }
 
-  private async newPartnerAccessTherapy(user: IUser, simplyBookDto: ZapierSimplybookBodyDto) {
+  private async newPartnerAccessTherapy(user: IUser, simplyBookDto: SimplybookBodyDto) {
     const partnerAccesses = await this.partnerAccessRepository.find({
       where: {
         userId: user.id,
@@ -237,7 +290,7 @@ export class WebhooksService {
     partnerAccess.therapySessionsRedeemed += 1;
 
     try {
-      const serializedTherapySession = serializeZapierSimplyBookDtoToTherapySessionEntity(
+      const serializedTherapySession = serializeSimplybookDtoToTherapySessionEntity(
         simplyBookDto,
         partnerAccess,
       );
@@ -472,5 +525,4 @@ export class WebhooksService {
     // Create or update the resource/course/session record in our database
     return this.updateOrCreateStoryData(story, status);
   }
-
 }

--- a/src/webhooks/webhooks.service.ts
+++ b/src/webhooks/webhooks.service.ts
@@ -94,33 +94,42 @@ export class WebhooksService {
 
     // Reconcile bookingId. The lookup uses clientEmail + bookingCode, so a mismatched
     // bookingId means we matched the wrong record (or Simplybook reused a code) — bail
-    // out rather than silently overwrite and risk corrupting accounting.
+    // out rather than silently overwrite and risk corrupting accounting. Simplybook will
+    // retry the webhook, so we Slack-alert to surface it for manual investigation rather
+    // than letting 409s pile up silently.
     if (simplyBookDto.booking_id !== undefined) {
       if (existingTherapySession.bookingId == null) {
         existingTherapySession.bookingId = simplyBookDto.booking_id;
       } else if (existingTherapySession.bookingId !== simplyBookDto.booking_id) {
         const error = `UpdatePartnerAccessTherapy - bookingId mismatch for booking_code ${booking_code}: existing ${existingTherapySession.bookingId}, incoming ${simplyBookDto.booking_id}`;
         this.logger.error(error);
+        await this.slackMessageClient.sendMessageToTherapySlackChannel(
+          `Simplybook webhook bookingId mismatch 🚨 booking_code ${booking_code}: local record has bookingId ${existingTherapySession.bookingId}, webhook claims ${simplyBookDto.booking_id}. Manual investigation required.`,
+        );
         throw new HttpException(error, HttpStatus.CONFLICT);
       }
     }
 
-    // If the booking is cancelled, increment the therapy sessions remaining on related partner access.
-    // Guard against duplicate webhook deliveries: only credit the session back once.
+    // If the booking is cancelled, credit the session back to the partner access counters.
+    // Guard against duplicate webhook deliveries: only credit back once (existing cancelledAt
+    // means we've already processed a cancel for this record).
+    // Atomic UPDATE statements (increment/decrement) avoid lost-update races if two cancel
+    // webhooks for different bookings on the same partnerAccess arrive concurrently.
     if (
       action === SIMPLYBOOK_ACTION_ENUM.CANCELLED_BOOKING &&
       !existingTherapySession.cancelledAt
     ) {
       try {
-        const partnerAccess = await this.partnerAccessRepository.findOneBy({
-          id: existingTherapySession.partnerAccessId,
-        });
-
-        partnerAccess.therapySessionsRemaining += 1;
-        partnerAccess.therapySessionsRedeemed -= 1;
-
-        await this.partnerAccessRepository.save(partnerAccess);
-
+        await this.partnerAccessRepository.increment(
+          { id: existingTherapySession.partnerAccessId },
+          'therapySessionsRemaining',
+          1,
+        );
+        await this.partnerAccessRepository.decrement(
+          { id: existingTherapySession.partnerAccessId },
+          'therapySessionsRedeemed',
+          1,
+        );
         existingTherapySession.cancelledAt = new Date();
       } catch (err) {
         const error = `UpdatePartnerAccessTherapy - error updating partner access for ${action} - userId ${user.id} - ${err?.message || 'unknown error'}`;
@@ -169,6 +178,23 @@ export class WebhooksService {
       const error = `Simplybook webhook received for unexpected company ${webhookDto.company}`;
       this.logger.error(error);
       throw new HttpException(error, HttpStatus.UNAUTHORIZED);
+    }
+
+    // Replay protection: reject webhooks outside a 5-minute window. Defends against an
+    // attacker who has captured a webhook URL with token replaying old payloads to
+    // re-trigger booking processing.
+    const replayWindowMs = 5 * 60 * 1000;
+    if (webhookDto.webhook_timestamp !== undefined) {
+      const ageMs = Date.now() - webhookDto.webhook_timestamp * 1000;
+      if (ageMs > replayWindowMs || ageMs < -replayWindowMs) {
+        const error = `Simplybook webhook rejected: timestamp ${webhookDto.webhook_timestamp} outside ${replayWindowMs}ms replay window (age ${ageMs}ms)`;
+        this.logger.warn(error);
+        throw new HttpException(error, HttpStatus.UNAUTHORIZED);
+      }
+    } else {
+      this.logger.warn(
+        `Simplybook webhook for booking ${webhookDto.booking_id} arrived without webhook_timestamp — replay window not enforced`,
+      );
     }
 
     if (webhookDto.notification_type === SimplybookNotificationType.NOTIFY) {
@@ -303,16 +329,25 @@ export class WebhooksService {
       throw new HttpException(error, HttpStatus.FORBIDDEN);
     }
 
-    partnerAccess.therapySessionsRemaining -= 1;
-    partnerAccess.therapySessionsRedeemed += 1;
-
     try {
+      // Atomic counter updates avoid lost-update races if two NEW_BOOKING webhooks
+      // for the same partnerAccess arrive concurrently.
+      await this.partnerAccessRepository.decrement(
+        { id: partnerAccess.id },
+        'therapySessionsRemaining',
+        1,
+      );
+      await this.partnerAccessRepository.increment(
+        { id: partnerAccess.id },
+        'therapySessionsRedeemed',
+        1,
+      );
+
       const serializedTherapySession = serializeSimplybookDtoToTherapySessionEntity(
         simplyBookDto,
         partnerAccess,
       );
 
-      await this.partnerAccessRepository.save(partnerAccess);
       const therapySession = await this.therapySessionRepository.save(serializedTherapySession);
 
       const updatedPartnerAccesses = await this.partnerAccessRepository.find({

--- a/test/utils/mockData.ts
+++ b/test/utils/mockData.ts
@@ -19,13 +19,18 @@ import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
 import { UserEntity } from 'src/entities/user.entity';
 import { EVENT_NAME } from 'src/event-logger/event-logger.interface';
 import { IFirebaseUser } from 'src/firebase/firebase-user.interface';
-import { ZapierSimplybookBodyDto } from 'src/partner-access/dtos/zapier-body.dto';
+import { SimplybookBookingDetails } from 'src/api/simplybook/simplybook-api';
+import { SimplybookBodyDto } from 'src/partner-access/dtos/simplybook-body.dto';
 import {
   EMAIL_REMINDERS_FREQUENCY,
   RESOURCE_CATEGORIES,
   SIMPLYBOOK_ACTION_ENUM,
   STORYBLOK_STORY_STATUS_ENUM,
 } from 'src/utils/constants';
+import {
+  SimplybookNotificationType,
+  SimplybookWebhookDto,
+} from 'src/webhooks/dtos/simplybook-webhook.dto';
 
 export const mockSessionStoryblokResult = {
   data: {
@@ -259,7 +264,7 @@ export const mockAltTherapySessionEntity = {
   user: { signUpLanguage: 'en' } as UserEntity,
 } as TherapySessionEntity;
 
-export const mockSimplybookBodyBase: ZapierSimplybookBodyDto = {
+export const mockSimplybookBodyBase: SimplybookBodyDto = {
   action: SIMPLYBOOK_ACTION_ENUM.UPDATED_BOOKING,
   start_date_time: '2022-09-12T07:30:00+0000',
   end_date_time: '2022-09-12T08:30:00+0000',
@@ -270,6 +275,24 @@ export const mockSimplybookBodyBase: ZapierSimplybookBodyDto = {
   service_name: 'bloom therapy',
   service_provider_email: 'therapist@test.com',
   service_provider_name: 'Therapist name',
+};
+
+export const mockSimplybookWebhookDto: SimplybookWebhookDto = {
+  booking_id: 123,
+  booking_hash: 'abc123def456abc123def456abc123de',
+  company: 'chayn',
+  notification_type: SimplybookNotificationType.CREATE,
+};
+
+export const mockSimplybookBookingDetails: SimplybookBookingDetails = {
+  id: 123,
+  code: 'abc',
+  start_datetime: '2022-09-12T07:30:00+0000',
+  end_datetime: '2022-09-12T08:30:00+0000',
+  service: { name: 'bloom therapy' },
+  provider: { name: 'Therapist name', email: 'therapist@test.com' },
+  client: { email: 'testuser@test.com' },
+  additional_fields: [{ id: 1, field_name: 'user_id', value: 'userId2' }],
 };
 
 export const mockPartnerEntity = {

--- a/test/utils/mockData.ts
+++ b/test/utils/mockData.ts
@@ -30,7 +30,7 @@ import {
 import {
   SimplybookNotificationType,
   SimplybookWebhookDto,
-} from 'src/webhooks/dtos/simplybook-webhook.dto';
+} from 'src/webhooks/dto/simplybook-webhook.dto';
 
 export const mockSessionStoryblokResult = {
   data: {
@@ -279,7 +279,6 @@ export const mockSimplybookBodyBase: SimplybookBodyDto = {
 
 export const mockSimplybookWebhookDto: SimplybookWebhookDto = {
   booking_id: 123,
-  booking_hash: 'abc123def456abc123def456abc123de',
   company: 'chayn',
   notification_type: SimplybookNotificationType.CREATE,
 };

--- a/test/utils/mockedServices.ts
+++ b/test/utils/mockedServices.ts
@@ -50,6 +50,9 @@ export const mockWebhooksServiceMethods: PartialFuncReturn<WebhooksService> = {
   updatePartnerAccessTherapy: async () => {
     return mockTherapySessionEntity;
   },
+  handleSimplybookWebhook: async () => {
+    return mockTherapySessionEntity;
+  },
 };
 
 export const mockClsService = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1871,6 +1871,44 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz#10b2944ca559386590683392022a897eefd011d3"
   integrity sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==
 
+"@otplib/core@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/core/-/core-12.0.1.tgz#73720a8cedce211fe5b3f683cd5a9c098eaf0f8d"
+  integrity sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==
+
+"@otplib/plugin-crypto@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz#2b42c624227f4f9303c1c041fca399eddcbae25e"
+  integrity sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==
+  dependencies:
+    "@otplib/core" "^12.0.1"
+
+"@otplib/plugin-thirty-two@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/plugin-thirty-two/-/plugin-thirty-two-12.0.1.tgz#5cc9b56e6e89f2a1fe4a2b38900ca4e11c87aa9e"
+  integrity sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==
+  dependencies:
+    "@otplib/core" "^12.0.1"
+    thirty-two "^1.0.2"
+
+"@otplib/preset-default@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/preset-default/-/preset-default-12.0.1.tgz#cb596553c08251e71b187ada4a2246ad2a3165ba"
+  integrity sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==
+  dependencies:
+    "@otplib/core" "^12.0.1"
+    "@otplib/plugin-crypto" "^12.0.1"
+    "@otplib/plugin-thirty-two" "^12.0.1"
+
+"@otplib/preset-v11@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/preset-v11/-/preset-v11-12.0.1.tgz#4c7266712e7230500b421ba89252963c838fc96d"
+  integrity sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==
+  dependencies:
+    "@otplib/core" "^12.0.1"
+    "@otplib/plugin-crypto" "^12.0.1"
+    "@otplib/plugin-thirty-two" "^12.0.1"
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
@@ -6248,6 +6286,15 @@ orderedmap@^2.0.0:
   resolved "https://registry.yarnpkg.com/orderedmap/-/orderedmap-2.1.1.tgz#61481269c44031c449915497bf5a4ad273c512d2"
   integrity sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==
 
+otplib@^12.0.1:
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/otplib/-/otplib-12.0.1.tgz#c1d3060ab7aadf041ed2960302f27095777d1f73"
+  integrity sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==
+  dependencies:
+    "@otplib/core" "^12.0.1"
+    "@otplib/preset-default" "^12.0.1"
+    "@otplib/preset-v11" "^12.0.1"
+
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -7470,6 +7517,11 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
+
+thirty-two@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/thirty-two/-/thirty-two-1.0.2.tgz#4ca2fffc02a51290d2744b9e3f557693ca6b627a"
+  integrity sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==
 
 tinyglobby@^0.2.15:
   version "0.2.16"


### PR DESCRIPTION
…nd bypass Zapier

### What changes did you make and why did you make them?
This release replaces the Zapier-mediated Simplybook webhook flow with a direct webhook from Simplybook to the backend. The Zapier endpoint (`POST /api/webhooks/simplybook`) is kept live — Zapier cleanup is a separate step after this release is confirmed working in production.

---

## Changes in this release

- New endpoint: `POST /api/webhooks/simplybook-admin?token=<secret>` — receives webhooks directly from Simplybook
- Simplybook admin API authentication now supports 2FA (TOTP via Google Authenticator)
- Auth token is cached in memory (55 min TTL) to avoid hitting Simplybook's rate limit
- `bookingId` is now saved on therapy sessions at booking time, so cancel no longer requires an extra Simplybook API lookup
- Three new environment variables: `SIMPLYBOOK_WEBHOOK_SECRET`, `SIMPLYBOOK_TOTP_SECRET`, updated `SIMPLYBOOK_CREDENTIALS`

