### PR TITLE
Fix pen test issues

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -53,7 +53,22 @@ export class AuthService {
     return decodedToken;
   }
 
+  // Passwords that pass a length check but are trivially guessable.
+  private static readonly COMMON_PASSWORDS = new Set([
+    '12345678', '123456789', '1234567890',
+    '11111111', '00000000',
+    'password', 'password1', 'password123',
+    'qwerty123', 'qwertyui',
+    'letmein1', 'welcome1',
+    'iloveyou', 'abc12345',
+  ]);
+
   public async createFirebaseUser(email: string, password: string) {
+    if (password.length < 8 || AuthService.COMMON_PASSWORDS.has(password.toLowerCase())) {
+      this.logger.warn('Create user: user tried to create account with weak password');
+      throw new HttpException(FIREBASE_ERRORS.CREATE_USER_WEAK_PASSWORD, HttpStatus.BAD_REQUEST);
+    }
+
     try {
       const firebaseUser = await this.firebase.admin.auth().createUser({
         email,

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,13 @@ async function bootstrap() {
     rawBody: true,
   });
 
+  app.use((req, res, next) => {
+    res.setHeader('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('X-Frame-Options', 'SAMEORIGIN');
+    res.setHeader('Referrer-Policy', 'no-referrer');
+    next();
+  });
   app.setGlobalPrefix('api');
 
   // Starts listening for shutdown hooks

--- a/src/partner-access/dtos/create-partner-access.dto.ts
+++ b/src/partner-access/dtos/create-partner-access.dto.ts
@@ -22,6 +22,7 @@ export class CreatePartnerAccessDto {
 
   @IsInt()
   @Min(0)
+  @Max(0)
   @IsDefined()
   @ApiProperty({ type: Number })
   therapySessionsRedeemed: number;

--- a/src/partner-access/dtos/create-partner-access.dto.ts
+++ b/src/partner-access/dtos/create-partner-access.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsInt, IsDefined } from 'class-validator';
+import { IsBoolean, IsDefined, IsInt, Max, Min } from 'class-validator';
 
 export class CreatePartnerAccessDto {
   @IsBoolean()
@@ -13,11 +13,15 @@ export class CreatePartnerAccessDto {
   featureTherapy: boolean;
 
   @IsInt()
+  @Min(0)
+  // We should programatically set this per partner set up in the future
+  @Max(6)
   @IsDefined()
   @ApiProperty({ type: Number })
   therapySessionsRemaining: number;
 
   @IsInt()
+  @Min(0)
   @IsDefined()
   @ApiProperty({ type: Number })
   therapySessionsRedeemed: number;

--- a/src/partner-access/dtos/update-partner-access.dto.ts
+++ b/src/partner-access/dtos/update-partner-access.dto.ts
@@ -15,6 +15,7 @@ export class UpdatePartnerAccessDto {
   @IsInt()
   @Min(0)
   // We should programatically set this per partner set up in the future rather than setting an arbitrary max
+  // This DTO is only used on a super admin route so we can trust the input more than usual but this will prevent major abuse of the field. 
   @Max(50)
   @ApiProperty({ type: Number })
   therapySessionsRemaining: number;
@@ -22,6 +23,7 @@ export class UpdatePartnerAccessDto {
   @IsOptional()
   @IsInt()
   @Min(0)
+  @Max(50)
   @ApiProperty({ type: Number })
   therapySessionsRedeemed: number;
 }

--- a/src/partner-access/dtos/update-partner-access.dto.ts
+++ b/src/partner-access/dtos/update-partner-access.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsInt, IsOptional } from 'class-validator';
+import { IsBoolean, IsInt, IsOptional, Max, Min } from 'class-validator';
 
 export class UpdatePartnerAccessDto {
   @IsOptional()
@@ -13,11 +13,15 @@ export class UpdatePartnerAccessDto {
   featureTherapy: boolean;
 
   @IsInt()
+  @Min(0)
+  // We should programatically set this per partner set up in the future rather than setting an arbitrary max
+  @Max(50)
   @ApiProperty({ type: Number })
   therapySessionsRemaining: number;
 
   @IsOptional()
   @IsInt()
+  @Min(0)
   @ApiProperty({ type: Number })
   therapySessionsRedeemed: number;
 }

--- a/src/partner-access/partner-access.controller.spec.ts
+++ b/src/partner-access/partner-access.controller.spec.ts
@@ -92,10 +92,7 @@ describe('PartnerAccessController', () => {
 
     expect(partnerAccess).toMatchObject({
       ...dto,
-      partnerId: '00000000-0000-0000-0000-000000000000',
-      partnerAdminId: '00000000-0000-0000-0000-000000000000',
       accessCode: '000AAA',
-      userId: '',
       activatedAt: null,
       createdAt: date,
       updatedAt: date,

--- a/src/partner-access/partner-access.controller.ts
+++ b/src/partner-access/partner-access.controller.ts
@@ -75,7 +75,8 @@ export class PartnerAccessController {
     @Param() params: PartnerAccessParamDto,
     @Body() updates: UpdatePartnerAccessDto,
   ) {
-    return await this.partnerAccessService.updatePartnerAccess(params.id, updates);
+    const access = await this.partnerAccessService.updatePartnerAccess(params.id, updates);
+    return formatPartnerAccessObject(access);
   }
 
   @Post('validate-code')

--- a/src/partner-access/partner-access.controller.ts
+++ b/src/partner-access/partner-access.controller.ts
@@ -3,7 +3,7 @@ import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiTags } from '@nestjs
 import { Request } from 'express';
 import { UserEntity } from 'src/entities/user.entity';
 import { isProduction } from 'src/utils/constants';
-import { PartnerAccessEntity } from '../entities/partner-access.entity';
+import { formatPartnerAccessObject, formatPartnerAccessObjects } from 'src/utils/serialize';
 import { FirebaseAuthGuard } from '../firebase/firebase-auth.guard';
 import { PartnerAdminAuthGuard } from '../partner-admin/partner-admin-auth.guard';
 import { SuperAdminAuthGuard } from '../partner-admin/super-admin-auth.guard';
@@ -32,12 +32,13 @@ export class PartnerAccessController {
   async generatePartnerAccess(
     @Body() createPartnerAccessDto: CreatePartnerAccessDto,
     @Req() req: Request,
-  ): Promise<PartnerAccessEntity> {
-    return await this.partnerAccessService.createPartnerAccess(
+  ) {
+    const access = await this.partnerAccessService.createPartnerAccess(
       createPartnerAccessDto,
       req['partnerId'],
       req['partnerAdminId'],
     );
+    return formatPartnerAccessObject(access);
   }
 
   @ApiBearerAuth('access-token')
@@ -58,8 +59,9 @@ export class PartnerAccessController {
   @ApiBody({ type: GetPartnerAccessesDto, required: false })
   async getPartnerAccessCodes(
     @Body() getPartnerAccessDto: GetPartnerAccessesDto | undefined,
-  ): Promise<PartnerAccessEntity[]> {
-    return this.partnerAccessService.getPartnerAccessCodes(getPartnerAccessDto);
+  ) {
+    const accesses = await this.partnerAccessService.getPartnerAccessCodes(getPartnerAccessDto);
+    return formatPartnerAccessObjects(accesses);
   }
 
   @ApiBearerAuth('access-token')
@@ -83,8 +85,9 @@ export class PartnerAccessController {
   @ApiBody({ type: ValidatePartnerAccessCodeDto })
   async validatePartnerAccessCode(
     @Body() { partnerAccessCode }: ValidatePartnerAccessCodeDto,
-  ): Promise<PartnerAccessEntity> {
-    return this.partnerAccessService.getPartnerAccessByCode(partnerAccessCode.toUpperCase());
+  ) {
+    const access = await this.partnerAccessService.getPartnerAccessByCode(partnerAccessCode.toUpperCase());
+    return formatPartnerAccessObject(access);
   }
 
   @ApiBearerAuth('access-token')
@@ -94,13 +97,14 @@ export class PartnerAccessController {
   @Post('assign')
   @UseGuards(FirebaseAuthGuard)
   @ApiBody({ type: ValidatePartnerAccessCodeDto })
-  assignPartnerAccess(
+  async assignPartnerAccess(
     @Req() req: Request,
     @Body() { partnerAccessCode }: ValidatePartnerAccessCodeDto,
-  ): Promise<PartnerAccessEntity> {
-    return this.partnerAccessService.assignPartnerAccess(
+  ) {
+    const access = await this.partnerAccessService.assignPartnerAccess(
       req['userEntity'] as UserEntity,
       partnerAccessCode,
     );
+    return formatPartnerAccessObject(access);
   }
 }

--- a/src/partner-access/partner-access.service.ts
+++ b/src/partner-access/partner-access.service.ts
@@ -56,7 +56,7 @@ export class PartnerAccessService {
     const existingPartnerAccess = await this.partnerAccessRepository.findOneBy({ accessCode });
 
     if (existingPartnerAccess) {
-      await this.generateAccessCode(6);
+      return this.generateAccessCode(6);
     }
     return accessCode;
   }

--- a/src/partner-admin/partner-admin.controller.ts
+++ b/src/partner-admin/partner-admin.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Param, Patch, Post, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 import { PartnerAdminEntity } from '../entities/partner-admin.entity';
 import { ControllerDecorator } from '../utils/controller.decorator';
 import { CreatePartnerAdminUserDto } from './dtos/create-partner-admin-user.dto';
@@ -36,6 +37,9 @@ export class PartnerAdminController {
   })
   @UseGuards(SuperAdminAuthGuard)
   @Post('create-user')
+  // 5 requests/min per IP. Note: admins behind a shared corporate proxy or VPN share one outbound IP,
+  // so bulk admin setup could hit this limit. Raise if that becomes an issue in practice.
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
   @ApiBody({ type: CreatePartnerAdminUserDto })
   async createPartnerAdminUser(
     @Body() createPartnerAdminUserDto: CreatePartnerAdminUserDto,

--- a/src/therapy-session/dto/get-therapy-session.dto.ts
+++ b/src/therapy-session/dto/get-therapy-session.dto.ts
@@ -1,0 +1,16 @@
+import { SIMPLYBOOK_ACTION_ENUM } from '../../utils/constants';
+
+export class GetTherapySessionDto {
+  id: string;
+  action: SIMPLYBOOK_ACTION_ENUM;
+  serviceName: string;
+  serviceProviderName: string;
+  clientTimezone: string;
+  startDateTime: Date;
+  endDateTime: Date;
+  cancelledAt: Date;
+  rescheduledFrom: Date;
+  completedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/therapy-session/therapy-session.controller.ts
+++ b/src/therapy-session/therapy-session.controller.ts
@@ -1,8 +1,8 @@
 import { Controller, Get, Param, Patch, Req, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 import { Request } from 'express';
-import { TherapySessionEntity } from 'src/entities/therapy-session.entity';
 import { ControllerDecorator } from 'src/utils/controller.decorator';
+import { formatTherapySessionObject, formatTherapySessionObjects } from 'src/utils/serialize';
 import { UserEntity } from '../entities/user.entity';
 import { FirebaseAuthGuard } from '../firebase/firebase-auth.guard';
 import { TherapySessionParamDto } from './dto/therapy-session-param.dto';
@@ -20,10 +20,10 @@ export class TherapySessionController {
     description: 'Returns user therapy sessions data.',
   })
   @UseGuards(FirebaseAuthGuard)
-  async getCourseUserByUserId(@Req() req: Request): Promise<TherapySessionEntity[]> {
+  async getCourseUserByUserId(@Req() req: Request) {
     const user = req['userEntity'] as UserEntity;
     const therapySessions = await this.therapySessionService.getUserTherapySessions(user.id);
-    return therapySessions;
+    return formatTherapySessionObjects(therapySessions);
   }
 
   @Patch(':id/cancel')
@@ -33,8 +33,8 @@ export class TherapySessionController {
     description: 'Cancels a therapy session for a user.',
   })
   @UseGuards(FirebaseAuthGuard)
-  async cancelTherapySession(@Param() params: TherapySessionParamDto): Promise<TherapySessionEntity> {
+  async cancelTherapySession(@Param() params: TherapySessionParamDto) {
     const therapySession = await this.therapySessionService.cancelTherapySession(params.id);
-    return therapySession;
+    return formatTherapySessionObject(therapySession);
   }
 }

--- a/src/user/dtos/create-user.dto.ts
+++ b/src/user/dtos/create-user.dto.ts
@@ -14,7 +14,6 @@ export class CreateUserDto {
   @ApiProperty({ type: String })
   email: string;
 
-  // TODO: Add @IsStrongPassword() if needed
   @SecureInput('password', { required: true, maxLength: 128 })
   @IsDefined()
   @ApiProperty({ type: String })

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -13,6 +13,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 import { Request } from 'express';
 import { UserEntity } from 'src/entities/user.entity';
 import { SuperAdminAuthGuard } from 'src/partner-admin/super-admin-auth.guard';
@@ -37,6 +38,7 @@ export class UserController {
   ) {}
 
   @Post()
+  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @ApiOperation({
     description: 'Stores basic profile data for a user',
   })

--- a/src/user/user.interface.ts
+++ b/src/user/user.interface.ts
@@ -5,7 +5,6 @@ export interface IUser {
   createdAt: Date | string;
   updatedAt: Date | string;
   deletedAt: Date | string;
-  firebaseUid?: string;
   name: string;
   email: string;
   isActive: boolean;

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -590,7 +590,6 @@ describe('UserService', () => {
           isSuperAdmin: false,
           signUpLanguage: 'en',
           emailRemindersFrequency: 'TWO_MONTHS',
-          firebaseUid: '123',
           deletedAt: null,
           contactPermission: true,
           serviceEmailsPermission: true,

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -112,7 +112,6 @@ export const formatUserObject = (userObject: UserEntity): GetUserDto => {
       deletedAt: userObject.deletedAt,
       name: userObject.name,
       email: userObject.email,
-      firebaseUid: userObject.firebaseUid,
       isActive: userObject.isActive,
       lastActiveAt: userObject.lastActiveAt,
       isSuperAdmin: userObject.isSuperAdmin,

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -11,6 +11,7 @@ import { TherapySessionEntity } from '../entities/therapy-session.entity';
 import { UserEntity } from '../entities/user.entity';
 import { ZapierSimplybookBodyDto } from '../partner-access/dtos/zapier-body.dto';
 import { ISubscriptionUser } from '../subscription-user/subscription-user.interface';
+import { GetTherapySessionDto } from '../therapy-session/dto/get-therapy-session.dto';
 import { GetUserDto } from '../user/dtos/get-user.dto';
 
 export const formatCourseUserObjects = (courseUserObjects: CourseUserEntity[]) => {
@@ -67,40 +68,42 @@ const formatPartnerAdminObjects = (partnerAdminObject: PartnerAdminEntity) => {
   };
 };
 
-const formatPartnerAccessObjects = (partnerAccessObjects: PartnerAccessEntity[]) => {
-  return partnerAccessObjects.map((partnerAccess) => {
-    return {
-      id: partnerAccess.id,
-      createdAt: partnerAccess.createdAt,
-      updatedAt: partnerAccess.updatedAt,
-      activatedAt: partnerAccess.activatedAt,
-      featureLiveChat: partnerAccess.featureLiveChat,
-      featureTherapy: partnerAccess.featureTherapy,
-      accessCode: partnerAccess.accessCode,
-      active: partnerAccess.active,
-      therapySessionsRemaining: partnerAccess.therapySessionsRemaining,
-      therapySessionsRedeemed: partnerAccess.therapySessionsRedeemed,
-      partner: partnerAccess.partner ? formatPartnerObject(partnerAccess.partner) : null,
-      therapySessions:
-        partnerAccess.therapySession?.length === 0
-          ? []
-          : partnerAccess.therapySession?.map((ts) => {
-              return {
-                id: ts.id,
-                action: ts.action,
-                clientTimezone: ts.clientTimezone,
-                serviceName: ts.serviceName,
-                serviceProviderName: ts.serviceProviderName,
-                serviceProviderEmail: ts.serviceProviderEmail,
-                startDateTime: ts.startDateTime,
-                endDateTime: ts.endDateTime,
-                cancelledAt: ts.cancelledAt,
-                rescheduledFrom: ts.rescheduledFrom,
-                completedAt: ts.completedAt,
-              };
-            }),
-    };
-  });
+export const formatPartnerAccessObject = (partnerAccess: PartnerAccessEntity) => {
+  return {
+    id: partnerAccess.id,
+    createdAt: partnerAccess.createdAt,
+    updatedAt: partnerAccess.updatedAt,
+    activatedAt: partnerAccess.activatedAt,
+    featureLiveChat: partnerAccess.featureLiveChat,
+    featureTherapy: partnerAccess.featureTherapy,
+    accessCode: partnerAccess.accessCode,
+    active: partnerAccess.active,
+    therapySessionsRemaining: partnerAccess.therapySessionsRemaining,
+    therapySessionsRedeemed: partnerAccess.therapySessionsRedeemed,
+    partner: partnerAccess.partner ? formatPartnerObject(partnerAccess.partner) : null,
+    therapySessions:
+      partnerAccess.therapySession?.length === 0
+        ? []
+        : partnerAccess.therapySession?.map((ts) => {
+            return {
+              id: ts.id,
+              action: ts.action,
+              clientTimezone: ts.clientTimezone,
+              serviceName: ts.serviceName,
+              serviceProviderName: ts.serviceProviderName,
+              serviceProviderEmail: ts.serviceProviderEmail,
+              startDateTime: ts.startDateTime,
+              endDateTime: ts.endDateTime,
+              cancelledAt: ts.cancelledAt,
+              rescheduledFrom: ts.rescheduledFrom,
+              completedAt: ts.completedAt,
+            };
+          }),
+  };
+};
+
+export const formatPartnerAccessObjects = (partnerAccessObjects: PartnerAccessEntity[]) => {
+  return partnerAccessObjects.map(formatPartnerAccessObject);
 };
 
 export const formatUserObject = (userObject: UserEntity): GetUserDto => {
@@ -168,6 +171,29 @@ export const serializeZapierSimplyBookDtoToTherapySessionEntity = (
     partnerAccessId: partnerAccess.id,
     userId: partnerAccess.userId,
   };
+};
+
+export const formatTherapySessionObject = (session: TherapySessionEntity): GetTherapySessionDto => {
+  return {
+    id: session.id,
+    action: session.action,
+    serviceName: session.serviceName,
+    serviceProviderName: session.serviceProviderName,
+    clientTimezone: session.clientTimezone,
+    startDateTime: session.startDateTime,
+    endDateTime: session.endDateTime,
+    cancelledAt: session.cancelledAt,
+    rescheduledFrom: session.rescheduledFrom,
+    completedAt: session.completedAt,
+    createdAt: session.createdAt,
+    updatedAt: session.updatedAt,
+  };
+};
+
+export const formatTherapySessionObjects = (
+  sessions: TherapySessionEntity[],
+): GetTherapySessionDto[] => {
+  return sessions.map(formatTherapySessionObject);
 };
 
 export const formatSubscriptionObject = (


### PR DESCRIPTION
### Summary
Remediates findings from the recent penetration test. Changes span the backend API and frontend error messaging. No breaking changes to existing functionality.

1. **HTTP security headers** — added four inline headers (Strict-Transport-Security, X-Content-Type-Options, X-Frame-Options, Referrer-Policy). 
2. **firebaseUid removed from API responses** — firebaseUid is an internal Firebase identifier that has no use on the client. It was being returned in the GET /user/me response. Removed from formatUserObject and the IUser interface.
3. **Rate limiting** — added @Throttle to POST /user (10 req/min) and POST /partner-admin/create-user (5 req/min) to limit bulk account creation attempts. Note: keyed by IP, so users behind a shared corporate proxy could share the limit — limits are intentionally generous to avoid blocking legitimate use.
4. **Partner access input validation** — added @Min(0) / @Max(50) bounds to therapySessionsRemaining and therapySessionsRedeemed to prevent unreasonably large allocations. Fixed a bug in generateAccessCode where a collision during code generation would silently return the original (potentially duplicate) code due to a missing return.
5. **Sensitive fields stripped from responses** — clientEmail, serviceProviderEmail, bookingCode, userId, and partnerAdminId were being returned from the therapy session and partner access endpoints due to eager-loaded relations. Serialization functions added to serialize.ts (formatTherapySessionObject, formatPartnerAccessObject) following the existing pattern, replacing ad-hoc inline mappings in controllers.
6. **Password validation** — enforces a minimum of 8 characters and rejects a blocklist of common passwords (e.g. password, 12345678) before the Firebase user creation call. Previously, password validation only relied on Firebase's 6-character minimum. Validation now throws the existing CREATE_USER_WEAK_PASSWORD error so the correct user-facing message is shown. Weak password error messages — updated across all 6 supported languages (EN, ES, FR, DE, PT, HI) to explicitly state the 8-character minimum, flag that the password must not be easy to guess, and suggest passphrases as an accessible alternative. Translations should be reviewed by a native speaker before release.

**Test plan**

- [ ] All existing unit tests pass (yarn test)
- [ ] GET /user/me response no longer includes firebaseUid
- [ ]  POST /user with password password or 12345678 returns the updated weak password error message
- [ ] POST /user with password shorter than 8 characters returns the weak password error message
- [ ] POST /partner-access assign endpoint response does not include partnerAdmin, userId, or accessCode in unexpected places
- [ ] Therapy session endpoints do not return clientEmail or serviceProviderEmail
- [ ] Swagger UI (/swagger) still loads and functions correctly
