### PR TITLE
Log recreate profiles error + migrate rerun specific emails

### DIFF
--- a/src/api/mailchimp/mailchimp-api.ts
+++ b/src/api/mailchimp/mailchimp-api.ts
@@ -51,6 +51,9 @@ function formatMailchimpError(error: unknown): string {
   return `status=${status} ${detail}`;
 }
 
+// PUT-based upsert: creates new members, updates existing, and reactivates archived ones.
+// addListMember (POST) returns 400 "Member Exists" for archived members, which would block
+// the recovery flows that recreate profiles after manual archive/deletion.
 export const createMailchimpProfile = async (
   profileData: Partial<UpdateListMemberRequest>,
 ): Promise<ListMember> => {
@@ -60,7 +63,11 @@ export const createMailchimpProfile = async (
   }
 
   try {
-    return await mailchimp.lists.addListMember(mailchimpAudienceId, profileData);
+    return await mailchimp.lists.setListMember(
+      mailchimpAudienceId,
+      getEmailMD5Hash(profileData.email_address),
+      { ...profileData, status_if_new: profileData.status ?? 'subscribed' },
+    );
   } catch (error) {
     throw new Error(`Create mailchimp profile API call failed: ${formatMailchimpError(error)}`, {
       cause: error,
@@ -273,8 +280,13 @@ export const sendMailchimpUserEvent = async (email: string, event: MAILCHIMP_CUS
       name: event,
     });
   } catch (error) {
-    throw new Error(`Send mailchimp user event failed: ${error?.message || 'unknown error'}`, {
-      cause: error,
-    });
+    // Surface status on the thrown error so callers can detect 404 (archived/missing member)
+    // and recover by recreating the profile before retrying the event.
+    const apiError = new Error(
+      `Send mailchimp user event failed: ${formatMailchimpError(error)}`,
+      { cause: error },
+    ) as Error & { status?: number };
+    apiError.status = (error as { status?: number })?.status;
+    throw apiError;
   }
 };

--- a/src/crisp-migration/crisp-migration.service.ts
+++ b/src/crisp-migration/crisp-migration.service.ts
@@ -125,10 +125,19 @@ export class CrispMigrationService {
     let conversations = await this.crispExport.getConversationsSince(since);
 
     if (options.specificEmail) {
-      conversations = conversations.filter(
-        (c) => (c.meta?.email ?? c.email)?.toLowerCase() === options.specificEmail!.toLowerCase(),
+      const emails = new Set(
+        options.specificEmail
+          .split(',')
+          .map((e) => e.trim().toLowerCase())
+          .filter((e) => e.length > 0),
       );
-      logger.log(`Filtered to ${conversations.length} conversations for ${options.specificEmail}`);
+      conversations = conversations.filter((c) => {
+        const email = (c.meta?.email ?? c.email)?.toLowerCase();
+        return email ? emails.has(email) : false;
+      });
+      logger.log(
+        `Filtered to ${conversations.length} conversations for ${emails.size} email(s): ${[...emails].join(', ')}`,
+      );
     } else if (options.emailDomainFilter) {
       const domain = options.emailDomainFilter.toLowerCase();
       conversations = conversations.filter((c) =>

--- a/src/crisp-migration/crisp-migration.service.ts
+++ b/src/crisp-migration/crisp-migration.service.ts
@@ -158,7 +158,7 @@ export class CrispMigrationService {
           () =>
             this.migrateUser(email, convs, since, options),
       ),
-      3,
+      1,
     );
   }
 

--- a/src/crisp-migration/dto/migration-options.dto.ts
+++ b/src/crisp-migration/dto/migration-options.dto.ts
@@ -19,7 +19,7 @@ export class MigrationOptionsDto {
 
   @IsOptional()
   @IsString()
-  specificEmail?: string; // Migrate only a specific contact
+  specificEmail?: string; // Migrate only specific contacts — single email or comma-separated list (e.g. "a@x.com,b@y.com")
 
   @IsOptional()
   @IsString()

--- a/src/front-chat/front-chat-webhook.service.ts
+++ b/src/front-chat/front-chat-webhook.service.ts
@@ -149,7 +149,11 @@ export class FrontChatWebhookService {
             );
           }
         })
-        .catch(() => {});
+        .catch((err) => {
+          this.logger.error(
+            `Front Channel: failed to set lastMessageReceivedAt for ${recipientEmail}: ${(err as Error)?.message || 'unknown error'}`,
+          );
+        });
     } else {
       this.logger.warn(
         `Front Channel: missing recipient or body (recipient=${recipientEmail}, hasBody=${!!messageBody})`,

--- a/src/front-chat/front-chat.gateway.ts
+++ b/src/front-chat/front-chat.gateway.ts
@@ -147,7 +147,11 @@ export class FrontChatGateway implements OnGatewayConnection, OnGatewayDisconnec
       if (!existingChatUser?.frontContactId) {
         await this.awaitFrontContactReady(user);
       }
-      const chatUser = await this.frontChatService.sendChannelTextMessage(user, payload.text, existingChatUser);
+      const chatUser = await this.frontChatService.sendChannelTextMessage(
+        user,
+        payload.text,
+        existingChatUser,
+      );
 
       if (chatUser) {
         this.serviceUserProfilesService

--- a/src/front-chat/front-chat.scheduler.ts
+++ b/src/front-chat/front-chat.scheduler.ts
@@ -1,15 +1,18 @@
 import { Injectable } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
-import { sendMailchimpUserEvent } from 'src/api/mailchimp/mailchimp-api';
 import { MAILCHIMP_CUSTOM_EVENTS } from 'src/api/mailchimp/mailchimp-api.interfaces';
 import { Logger } from 'src/logger/logger';
+import { ServiceUserProfilesService } from 'src/service-user-profiles/service-user-profiles.service';
 import { FrontChatService } from './front-chat.service';
 
 @Injectable()
 export class FrontChatScheduler {
   private readonly logger = new Logger('FrontChatScheduler');
 
-  constructor(private readonly frontChatService: FrontChatService) {}
+  constructor(
+    private readonly frontChatService: FrontChatService,
+    private readonly serviceUserProfilesService: ServiceUserProfilesService,
+  ) {}
 
   @Cron(CronExpression.EVERY_MINUTE)
   async checkUnreadMessages(): Promise<void> {
@@ -30,13 +33,12 @@ export class FrontChatScheduler {
           );
           return;
         }
-        try {
-          await sendMailchimpUserEvent(email, MAILCHIMP_CUSTOM_EVENTS.FRONT_MESSAGE_UNREAD);
-        } catch (err) {
-          this.logger.warn(
-            `FrontChatScheduler: failed to notify ${email}: ${(err as Error)?.message || 'unknown error'}`,
-          );
-        }
+        // Recovery wrapper: recreates an archived/missing Mailchimp profile before retrying
+        // the event so the unread-message email still fires.
+        await this.serviceUserProfilesService.sendMailchimpUserEventWithRecovery(
+          email,
+          MAILCHIMP_CUSTOM_EVENTS.FRONT_MESSAGE_UNREAD,
+        );
       }),
     );
   }

--- a/src/front-chat/front-chat.scheduler.ts
+++ b/src/front-chat/front-chat.scheduler.ts
@@ -21,7 +21,7 @@ export class FrontChatScheduler {
 
     this.logger.log(`FrontChatScheduler: notifying ${unread.length} user(s) of unread messages`);
 
-    await Promise.allSettled(
+    const results = await Promise.allSettled(
       unread.map(async ({ chatUser, email }) => {
         // Mark notified in the DB before sending so a restart between these two
         // operations doesn't cause a duplicate notification on the next cron fire.
@@ -41,5 +41,13 @@ export class FrontChatScheduler {
         );
       }),
     );
+
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        this.logger.error(
+          `FrontChatScheduler: unhandled error sending unread notification: ${(result.reason as Error)?.message || result.reason}`,
+        );
+      }
+    }
   }
 }

--- a/src/front-chat/front-chat.service.ts
+++ b/src/front-chat/front-chat.service.ts
@@ -54,7 +54,27 @@ async function fetchFrontWithRetry(url: string, init: RequestInit): Promise<Resp
   }
 }
 
-async function frontApiRequest(method: string, path: string, body?: unknown): Promise<unknown> {
+// Per-minute rate limits don't embed a retry-in time in the error body — default to 60 s so
+// we clear the window rather than hammering Front with rapid retries that will 429 again.
+const FRONT_429_RETRY_DELAYS_MS = [500, 5_000, 60_000];
+
+function parseFrontRetryDelayMs(errorBody: string): number | undefined {
+  try {
+    const parsed = JSON.parse(errorBody) as { _error?: { message?: string } };
+    const match = parsed._error?.message?.match(/retry in (\d+) milliseconds/i);
+    if (match) return parseInt(match[1], 10);
+  } catch {
+    // ignore
+  }
+  return undefined;
+}
+
+async function frontApiRequest(
+  method: string,
+  path: string,
+  body?: unknown,
+  attempt = 0,
+): Promise<unknown> {
   const response = await fetch(`${FRONT_API_BASE_URL}${path}`, {
     method,
     headers: {
@@ -66,6 +86,16 @@ async function frontApiRequest(method: string, path: string, body?: unknown): Pr
 
   if (!response.ok) {
     const errorBody = await response.text();
+
+    if (response.status === 429 && attempt < FRONT_429_RETRY_DELAYS_MS.length) {
+      const retryMs = parseFrontRetryDelayMs(errorBody) ?? FRONT_429_RETRY_DELAYS_MS[attempt];
+      logger.warn(
+        `Front API rate limited on ${method} ${path} — retrying in ${retryMs}ms (attempt ${attempt + 1}/${FRONT_429_RETRY_DELAYS_MS.length})`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, retryMs));
+      return frontApiRequest(method, path, body, attempt + 1);
+    }
+
     const error = new Error(
       `Front API ${method} ${path} failed (${response.status}): ${errorBody}`,
     ) as FrontApiError;

--- a/src/service-user-profiles/service-user-profiles.service.ts
+++ b/src/service-user-profiles/service-user-profiles.service.ts
@@ -5,11 +5,13 @@ import {
   batchUpdateMailchimpProfiles,
   createMailchimpMergeField,
   createMailchimpProfile,
+  sendMailchimpUserEvent,
   updateMailchimpProfile,
 } from 'src/api/mailchimp/mailchimp-api';
 import {
   ListMemberCustomFields,
   ListMemberPartial,
+  MAILCHIMP_CUSTOM_EVENTS,
   MAILCHIMP_MERGE_FIELD_TYPES,
 } from 'src/api/mailchimp/mailchimp-api.interfaces';
 import { ChatUserEntity } from 'src/entities/chat-user.entity';
@@ -181,15 +183,20 @@ export class ServiceUserProfilesService {
         );
       } catch (err) {
         if (this.isFrontContactNotFound(err)) {
-          logger.log(`Front contact missing for ${email} — creating with full custom fields`);
+          logger.warn(`Front contact missing for ${email} — creating with full custom fields`);
           await this.getOrCreateFrontContact(user);
         } else {
           throw err;
         }
       }
     } catch (error) {
+      const status =
+        (error as { cause?: { status?: number }; status?: number })?.cause?.status ??
+        (error as { status?: number })?.status;
       const message = error instanceof Error ? error.message : 'unknown error';
-      logger.error(`Sync Front Chat contact custom fields error for ${email}: ${message}`);
+      logger.error(
+        `Sync Front Chat contact custom fields error for ${email} (status=${status}): ${message}`,
+      );
     }
   }
 
@@ -216,12 +223,15 @@ export class ServiceUserProfilesService {
     try {
       await updateMailchimpProfile(partialUpdate, targetEmail);
     } catch (error) {
+      const status = (error as { status?: number })?.status;
       if (!this.isMailchimpNotFound(error)) {
         const message = error instanceof Error ? error.message : 'unknown error';
-        logger.error(`Update Mailchimp ${context} error - ${message}`);
+        logger.error(`Update Mailchimp ${context} error (status=${status}) - ${message}`);
         return;
       }
-      // 404 recovery — recreate from the full DB record so we don't leave a partial profile.
+      logger.warn(
+        `Mailchimp PATCH 404 for ${targetEmail} (${context}) — recreating profile from DB (lookup=${recoveryEmail})`,
+      );
       try {
         const user = await this.userRepository.findOne({
           where: { email: ILike(recoveryEmail) },
@@ -231,21 +241,67 @@ export class ServiceUserProfilesService {
           },
         });
         if (!user) {
-          logger.warn(`Mailchimp 404 recovery: no DB user for ${recoveryEmail}; skipping`);
+          logger.error(`Mailchimp 404 recovery: no DB user for ${recoveryEmail}`);
           return;
         }
         const chatUser = await this.frontChatService.getChatUser(user.id);
         const profileData = this.createCompleteMailchimpUserProfile(user, chatUser);
-
         profileData.merge_fields = {
           ...profileData.merge_fields,
           ...(partialUpdate.merge_fields ?? {}),
         };
         await createMailchimpProfile(profileData);
-        logger.log(`Recovered Mailchimp profile for ${user.email}`);
+        logger.warn(`Recreated Mailchimp profile for ${user.email}`);
       } catch (recoverError) {
+        const recoverStatus = (recoverError as { status?: number })?.status;
         const message = recoverError instanceof Error ? recoverError.message : 'unknown error';
-        logger.error(`Recover Mailchimp profile failed for ${recoveryEmail} - ${message}`);
+        logger.error(
+          `Recreate Mailchimp profile failed for ${recoveryEmail} (status=${recoverStatus}) - ${message}`,
+        );
+      }
+    }
+  }
+
+  // Send a Mailchimp custom event with 404 recovery — for archived/missing members,
+  // pipes through syncMailchimpProfile's existing recovery (PATCHes user data → 404 →
+  // recreates full profile) then retries the event so the email still fires.
+  async sendMailchimpUserEventWithRecovery(
+    email: string,
+    event: MAILCHIMP_CUSTOM_EVENTS,
+  ): Promise<void> {
+    if (isCypressTestEmail(email)) return;
+    try {
+      await sendMailchimpUserEvent(email, event);
+    } catch (error) {
+      const status = (error as { status?: number })?.status;
+      if (!this.isMailchimpNotFound(error)) {
+        const message = error instanceof Error ? error.message : 'unknown error';
+        logger.error(
+          `Send Mailchimp event ${event} for ${email} failed (status=${status}) - ${message}`,
+        );
+        return;
+      }
+      logger.warn(
+        `Mailchimp event ${event} 404 for ${email} — recreating profile via syncMailchimpProfile then retrying`,
+      );
+      const user = await this.userRepository.findOneBy({ email: ILike(email) });
+      if (!user) {
+        logger.error(`Cannot recover Mailchimp profile: no DB user for ${email}`);
+        return;
+      }
+      await this.syncMailchimpProfile(
+        this.serializeUserData(user).mailchimpSchema,
+        email,
+        `event ${event} pre-retry`,
+      );
+      try {
+        await sendMailchimpUserEvent(email, event);
+      } catch (retryError) {
+        const retryStatus = (retryError as { status?: number })?.status;
+        const message = retryError instanceof Error ? retryError.message : 'unknown error';
+        logger.error(
+          `Send Mailchimp event ${event} for ${email} retry failed (status=${retryStatus}) - ${message}`,
+        );
       }
     }
   }
@@ -274,16 +330,17 @@ export class ServiceUserProfilesService {
       try {
         await this.frontChatService.updateContactProfile(profilePayload, existingEmail);
       } catch (error) {
+        const status =
+          (error as { cause?: { status?: number }; status?: number })?.cause?.status ??
+          (error as { status?: number })?.status;
         if (this.isFrontContactNotFound(error)) {
-          // getOrCreateFrontContact creates at user.email with name + full custom fields, so
-          // no retry is needed (and retrying existingEmail would 404 again on email changes).
-          logger.log(
-            `Front contact missing for ${existingEmail} — creating at ${user.email} with full data`,
+          logger.warn(
+            `Front contact missing for ${existingEmail} (status=${status}) — creating at ${user.email} with full data`,
           );
           await this.getOrCreateFrontContact(user);
         } else {
           const message = error instanceof Error ? error.message : 'unknown error';
-          logger.error(`Update Front Chat user profile error - ${message}`);
+          logger.error(`Update Front Chat user profile error (status=${status}) - ${message}`);
         }
       }
     }

--- a/src/service-user-profiles/service-user-profiles.service.ts
+++ b/src/service-user-profiles/service-user-profiles.service.ts
@@ -284,17 +284,17 @@ export class ServiceUserProfilesService {
       logger.warn(
         `Mailchimp event ${event} 404 for ${email} — recreating profile via syncMailchimpProfile then retrying`,
       );
-      const user = await this.userRepository.findOneBy({ email: ILike(email) });
-      if (!user) {
-        logger.error(`Cannot recover Mailchimp profile: no DB user for ${email}`);
-        return;
-      }
-      await this.syncMailchimpProfile(
-        this.serializeUserData(user).mailchimpSchema,
-        email,
-        `event ${event} pre-retry`,
-      );
       try {
+        const user = await this.userRepository.findOneBy({ email: ILike(email) });
+        if (!user) {
+          logger.error(`Cannot recover Mailchimp profile: no DB user for ${email}`);
+          return;
+        }
+        await this.syncMailchimpProfile(
+          this.serializeUserData(user).mailchimpSchema,
+          email,
+          `event ${event} pre-retry`,
+        );
         await sendMailchimpUserEvent(email, event);
       } catch (retryError) {
         const retryStatus = (retryError as { status?: number })?.status;


### PR DESCRIPTION
Adds logs to help track why some mailchimp/front profiles arent recreated if they were previously deleted.

Also adds a temp support for multiple emails rerun on migration as some failed during first run.