### PR TITLE
Fix migrations

### DIFF
--- a/src/entities/chat-user.entity.ts
+++ b/src/entities/chat-user.entity.ts
@@ -11,7 +11,7 @@ export class ChatUserEntity extends BaseBloomEntity {
   @Column()
   userId: string;
 
-  @OneToOne(() => UserEntity)
+  @OneToOne(() => UserEntity, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'userId' })
   user: UserEntity;
 
@@ -36,7 +36,6 @@ export class ChatUserEntity extends BaseBloomEntity {
   @Column({
     type: 'enum',
     enum: UNREAD_NOTIFICATION_STATUS,
-    enumName: 'chat_user_unreadnotificationstatus_enum',
     nullable: true,
   })
   unreadNotificationStatus: UNREAD_NOTIFICATION_STATUS | null;

--- a/src/entities/session-feedback.entity.ts
+++ b/src/entities/session-feedback.entity.ts
@@ -12,10 +12,11 @@ export class SessionFeedbackEntity extends BaseBloomEntity {
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'sessionId' })
-  session: SessionEntity;
+  session: SessionEntity | null;
 
-  @Column({ name: 'sessionId' })
-  sessionId: string;
+  // Must remain nullable due to existing null values in prod database (following bug presesnt jan-dec 2025)
+  @Column({ name: 'sessionId', nullable: true })
+  sessionId: string | null;
 
   @Column()
   feedbackTags: FEEDBACK_TAGS_ENUM;

--- a/src/migrations/1782989961947-bloom-backend.ts
+++ b/src/migrations/1782989961947-bloom-backend.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class BloomBackend1782989961947 implements MigrationInterface {
+    name = 'BloomBackend1782989961947'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "chat_user" DROP CONSTRAINT "FK_chat_user_userId"`);
+        await queryRunner.query(`ALTER TABLE "chat_user" ADD CONSTRAINT "FK_5e9874ea3bd3524db95c2d88e53" FOREIGN KEY ("userId") REFERENCES "user"("userId") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "chat_user" DROP CONSTRAINT "FK_5e9874ea3bd3524db95c2d88e53"`);
+        await queryRunner.query(`ALTER TABLE "chat_user" ADD CONSTRAINT "FK_chat_user_userId" FOREIGN KEY ("userId") REFERENCES "user"("userId") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+}

--- a/src/typeorm.config.ts
+++ b/src/typeorm.config.ts
@@ -67,6 +67,7 @@ import { BloomBackend1777046400000 } from './migrations/1777046400000-bloom-back
 import { BloomBackend1777593600000 } from './migrations/1777593600000-bloom-backend';
 import { BloomBackend1779235200000 } from './migrations/1779235200000-bloom-backend';
 import { BloomBackend1779840000000 } from './migrations/1779840000000-bloom-backend';
+import { BloomBackend1782989961947 } from './migrations/1782989961947-bloom-backend';
 import { databaseUrl } from './utils/constants';
 
 config();
@@ -155,6 +156,7 @@ export const dataSourceOptions = {
     BloomBackend1777593600000,
     BloomBackend1779235200000,
     BloomBackend1779840000000,
+    BloomBackend1782989961947,
   ],
   subscribers: [],
   ssl: isProduction || isStaging,


### PR DESCRIPTION
Fixes alignment between entity and migrations/db. Running migrate was generating unintended changes e.g. non null resetting and also `FK_chat_user_userId` being renamed. This PR fixes these issues so that running a new migration returns no results as expected.