### PR TITLE
delete cypress users inclusive

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -161,7 +161,10 @@ export class AuthService {
         .listUsers(1000)
         .then((listUsersResult) => {
           listUsersResult.users.forEach((userRecord) => {
-            if (userRecord.email.includes('cypresstestemail')) {
+            // Match every Cypress test account variant (cypresstestemail+, cypresstestuser+, ...)
+            // scoped to @chayn.co so we never touch a real account.
+            const email = userRecord.email?.toLowerCase() ?? '';
+            if (email.includes('cypress') && email.endsWith('@chayn.co')) {
               allUsers.push(userRecord.uid);
             }
           });

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -67,8 +67,22 @@ export class UserController {
     return await this.userService.deleteUser(req['userEntity']);
   }
 
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    description: 'Returns the number of Cypress/automated-test accounts a bulk delete would remove',
+  })
+  @Get('/cypress/count')
+  @UseGuards(SuperAdminAuthGuard)
+  async countCypressUsers(): Promise<{ count: number }> {
+    return { count: await this.userService.countCypressTestUsers() };
+  }
+
   // This route must go before the Delete user route below as we want nestjs to check against this one first
   @ApiBearerAuth('access-token')
+  @ApiOperation({
+    description:
+      'Hard deletes all Cypress/automated-test accounts (DB rows cascade, plus Firebase, Front and Mailchimp). For superadmin cleanup of test data leaked into an environment.',
+  })
   @Delete('/cypress')
   @UseGuards(SuperAdminAuthGuard)
   async deleteCypressUsers(): Promise<UserEntity[]> {

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -2,7 +2,11 @@ import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { createMailchimpProfile, updateMailchimpProfile } from 'src/api/mailchimp/mailchimp-api';
+import {
+  createMailchimpProfile,
+  deleteMailchimpProfile,
+  updateMailchimpProfile,
+} from 'src/api/mailchimp/mailchimp-api';
 import { ChatUserService } from 'src/chat-user/chat-user.service';
 import { FrontChatService } from 'src/front-chat/front-chat.service';
 import { EventLogEntity } from 'src/entities/event-log.entity';
@@ -38,7 +42,7 @@ import { PartnerAccessService } from '../partner-access/partner-access.service';
 import { AdminUpdateUserDto } from './dtos/admin-update-user.dto';
 import { CreateUserDto } from './dtos/create-user.dto';
 import { UpdateUserDto } from './dtos/update-user.dto';
-import { UserService } from './user.service';
+import { CYPRESS_TEST_USER_EMAIL_FILTERS, UserService } from './user.service';
 
 const createUserDto: CreateUserDto = {
   email: 'user@email.com',
@@ -547,6 +551,60 @@ describe('UserService', () => {
       expect(mockTherapySessionServiceSpy).toHaveBeenCalledTimes(1);
       expect(mockSubscriptionUserServiceSpy).toHaveBeenCalledTimes(1);
       expect(mockAuthServiceSpy).toHaveBeenCalledWith(mockUserEntity.firebaseUid);
+    });
+  });
+
+  describe('countCypressTestUsers', () => {
+    it('counts users matching the shared Cypress test-email filters', async () => {
+      const repoCountSpy = jest.fn().mockResolvedValue(7);
+      repo.count = repoCountSpy as never;
+
+      const count = await service.countCypressTestUsers();
+
+      expect(count).toBe(7);
+      expect(repoCountSpy).toHaveBeenCalledWith({ where: CYPRESS_TEST_USER_EMAIL_FILTERS });
+    });
+  });
+
+  describe('deleteCypressTestUsers', () => {
+    it('hard deletes every matching test user across the db and third-party services', async () => {
+      const testUsers = [
+        { ...mockUserEntity, id: 'id-1', email: 'cypresstestemail+1@chayn.co' },
+        { ...mockUserEntity, id: 'id-2', email: 'cypresstestuser+2@chayn.co' },
+      ];
+      const repoFindSpy = jest.spyOn(repo, 'find').mockResolvedValue(testUsers as never);
+      const repoDeleteSpy = jest.fn().mockResolvedValue({ affected: 1 });
+      repo.delete = repoDeleteSpy as never;
+
+      const frontSpy = jest.spyOn(mockFrontChatService, 'deleteContact');
+      const firebaseSpy = jest.spyOn(mockAuthService, 'deleteFirebaseUser');
+
+      const deleted = await service.deleteCypressTestUsers();
+
+      // uses the shared broadened filter, not just cypresstestemail+
+      expect(repoFindSpy).toHaveBeenCalledWith({ where: CYPRESS_TEST_USER_EMAIL_FILTERS });
+      // hard delete of the db row (cascades to related tables), one call per user
+      expect(repoDeleteSpy).toHaveBeenCalledWith('id-1');
+      expect(repoDeleteSpy).toHaveBeenCalledWith('id-2');
+      // third-party contact cleanup per user
+      expect(frontSpy).toHaveBeenCalledWith('cypresstestemail+1@chayn.co');
+      expect(frontSpy).toHaveBeenCalledWith('cypresstestuser+2@chayn.co');
+      expect(createMailchimpProfile).not.toBe(undefined);
+      expect(deleteMailchimpProfile).toHaveBeenCalledWith('cypresstestuser+2@chayn.co');
+      expect(firebaseSpy).toHaveBeenCalledWith(mockUserEntity.firebaseUid);
+      expect(deleted).toHaveLength(2);
+    });
+
+    it('runs the orphaned-account clean up only when clean=true', async () => {
+      jest.spyOn(repo, 'find').mockResolvedValue([] as never);
+      repo.delete = jest.fn().mockResolvedValue({ affected: 0 }) as never;
+      const firebaseCleanSpy = jest.spyOn(mockAuthService, 'deleteCypressFirebaseUsers');
+
+      await service.deleteCypressTestUsers();
+      expect(firebaseCleanSpy).not.toHaveBeenCalled();
+
+      await service.deleteCypressTestUsers(true);
+      expect(firebaseCleanSpy).toHaveBeenCalled();
     });
   });
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -26,6 +26,11 @@ import { CreateUserDto } from './dtos/create-user.dto';
 import { GetUserDto } from './dtos/get-user.dto';
 import { UpdateUserDto } from './dtos/update-user.dto';
 
+export const CYPRESS_TEST_USER_EMAIL_FILTERS = [
+  { email: ILike('%cypress%@chayn.co') },
+  { email: ILike('test-%@chayn.co') },
+];
+
 @Injectable()
 export class UserService {
   private readonly logger = new Logger('UserService');
@@ -341,14 +346,17 @@ export class UserService {
     return deletedUsers;
   }
 
+  // Count of test accounts a bulk delete would remove — lets superadmins preview
+  // the impact before triggering the (irreversible) hard delete.
+  public async countCypressTestUsers(): Promise<number> {
+    return this.userRepository.count({ where: CYPRESS_TEST_USER_EMAIL_FILTERS });
+  }
+
   public async deleteCypressTestUsers(clean = false): Promise<UserEntity[]> {
     let deletedUsers: UserEntity[];
     try {
       const users = await this.userRepository.find({
-        where: [
-          { email: ILike('%cypresstestemail+%@chayn.co') },
-          { email: ILike('test-%@chayn.co') },
-        ],
+        where: CYPRESS_TEST_USER_EMAIL_FILTERS,
       });
 
       deletedUsers = await this.batchDeleteUsers(users);


### PR DESCRIPTION
Tweaks the delete cypress users functionality to include more email addresses and add a test, before its added to frontend superadmin UI