### PR TITLE
Fix messages received metric

### DIFF
--- a/src/api/mailchimp/mailchimp-api.ts
+++ b/src/api/mailchimp/mailchimp-api.ts
@@ -1,7 +1,7 @@
 import mailchimp from '@mailchimp/mailchimp_marketing';
 import { createHash } from 'crypto';
 import { mailchimpApiKey, mailchimpAudienceId, mailchimpServerPrefix } from 'src/utils/constants';
-import { isCypressTestEmail } from 'src/utils/utils';
+import { isCypressTestEmail, isProtectedReservedTestEmail } from 'src/utils/utils';
 import { Logger } from '../../logger/logger';
 import {
   ListMember,
@@ -263,6 +263,11 @@ export const deleteCypressMailchimpProfiles = async () => {
   logger.log(`Deleting ${cypressProfiles.members.length} mailchimp profiles`);
 
   for (const profile of cypressProfiles.members) {
+    // Skip reserved test accounts on non-production environments (see isProtectedReservedTestEmail)
+    if (isProtectedReservedTestEmail(profile.email_address)) {
+      logger.log('Skipping Mailchimp deletion for reserved Cypress test email');
+      continue;
+    }
     try {
       await deleteMailchimpProfile(profile.email_address);
     } catch (error) {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -8,6 +8,7 @@ import {
 import { DecodedIdToken } from 'firebase-admin/auth';
 import { Logger } from 'src/logger/logger';
 import { FIREBASE_ERRORS } from 'src/utils/errors';
+import { isProtectedReservedTestEmail } from 'src/utils/utils';
 import { FIREBASE } from '../firebase/firebase-factory';
 import { FirebaseServices } from '../firebase/firebase.types';
 import { UserAuthDto } from './dto/user-auth.dto';
@@ -163,7 +164,11 @@ export class AuthService {
             // Match every Cypress test account variant (cypresstestemail+, cypresstestuser+, ...)
             // scoped to @chayn.co so we never touch a real account.
             const email = userRecord.email?.toLowerCase() ?? '';
-            if (email.includes('cypress') && email.endsWith('@chayn.co')) {
+            if (
+              email.includes('cypress') &&
+              email.endsWith('@chayn.co') &&
+              !isProtectedReservedTestEmail(email)
+            ) {
               allUsers.push(userRecord.uid);
             }
           });

--- a/src/reporting/db-metrics.service.ts
+++ b/src/reporting/db-metrics.service.ts
@@ -160,16 +160,14 @@ export class DbMetricsService {
       ),
       // Authoritative chat message counts from event_log — distinct from the
       // GA4 CHAT_MESSAGE_SENT event which is lossy under ad-blockers / consent.
-      // `date` is the emit time from Front (webhook `emitted_at`), so it's the
-      // accurate timestamp for windowing — `createdAt` is when we wrote the row.
       tally('messagesSent', () =>
         this.eventLogRepository.count({
-          where: { event: EVENT_NAME.CHAT_MESSAGE_SENT, date: range },
+          where: { event: EVENT_NAME.CHAT_MESSAGE_SENT, createdAt: range },
         }),
       ),
       tally('messagesReceived', () =>
         this.eventLogRepository.count({
-          where: { event: EVENT_NAME.CHAT_MESSAGE_RECEIVED, date: range },
+          where: { event: EVENT_NAME.CHAT_MESSAGE_RECEIVED, createdAt: range },
         }),
       ),
     ]);

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -18,6 +18,7 @@ import { SubscriptionUserService } from 'src/subscription-user/subscription-user
 import { TherapySessionService } from 'src/therapy-session/therapy-session.service';
 import { EMAIL_REMINDERS_FREQUENCY, PartnerAccessCodeStatusEnum } from 'src/utils/constants';
 import { formatUserObject } from 'src/utils/serialize';
+import * as utils from 'src/utils/utils';
 import {
   mockIFirebaseUser,
   mockPartnerAccessEntity,
@@ -555,18 +556,44 @@ describe('UserService', () => {
   });
 
   describe('countCypressTestUsers', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
     it('counts users matching the shared Cypress test-email filters', async () => {
-      const repoCountSpy = jest.fn().mockResolvedValue(7);
-      repo.count = repoCountSpy as never;
+      const testUsers = [
+        { ...mockUserEntity, id: 'id-1', email: 'cypresstestemail+1@chayn.co' },
+        { ...mockUserEntity, id: 'id-2', email: 'cypresstestuser+2@chayn.co' },
+      ];
+      const repoFindSpy = jest.spyOn(repo, 'find').mockResolvedValue(testUsers as never);
 
       const count = await service.countCypressTestUsers();
 
-      expect(count).toBe(7);
-      expect(repoCountSpy).toHaveBeenCalledWith({ where: CYPRESS_TEST_USER_EMAIL_FILTERS });
+      expect(count).toBe(2);
+      expect(repoFindSpy).toHaveBeenCalledWith({ where: CYPRESS_TEST_USER_EMAIL_FILTERS });
+    });
+
+    it('excludes reserved test accounts from the count', async () => {
+      const testUsers = [
+        { ...mockUserEntity, id: 'id-1', email: 'cypresstestemail+1@chayn.co' },
+        { ...mockUserEntity, id: 'id-2', email: 'reserved@chayn.co' },
+      ];
+      jest.spyOn(repo, 'find').mockResolvedValue(testUsers as never);
+      jest
+        .spyOn(utils, 'isProtectedReservedTestEmail')
+        .mockImplementation((email) => email === 'reserved@chayn.co');
+
+      const count = await service.countCypressTestUsers();
+
+      expect(count).toBe(1);
     });
   });
 
   describe('deleteCypressTestUsers', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
     it('hard deletes every matching test user across the db and third-party services', async () => {
       const testUsers = [
         { ...mockUserEntity, id: 'id-1', email: 'cypresstestemail+1@chayn.co' },
@@ -593,6 +620,25 @@ describe('UserService', () => {
       expect(deleteMailchimpProfile).toHaveBeenCalledWith('cypresstestuser+2@chayn.co');
       expect(firebaseSpy).toHaveBeenCalledWith(mockUserEntity.firebaseUid);
       expect(deleted).toHaveLength(2);
+    });
+
+    it('skips reserved test accounts and never deletes them', async () => {
+      const testUsers = [
+        { ...mockUserEntity, id: 'id-1', email: 'cypresstestemail+1@chayn.co' },
+        { ...mockUserEntity, id: 'id-2', email: 'reserved@chayn.co' },
+      ];
+      jest.spyOn(repo, 'find').mockResolvedValue(testUsers as never);
+      const repoDeleteSpy = jest.fn().mockResolvedValue({ affected: 1 });
+      repo.delete = repoDeleteSpy as never;
+      jest
+        .spyOn(utils, 'isProtectedReservedTestEmail')
+        .mockImplementation((email) => email === 'reserved@chayn.co');
+
+      const deleted = await service.deleteCypressTestUsers();
+
+      expect(repoDeleteSpy).toHaveBeenCalledWith('id-1');
+      expect(repoDeleteSpy).not.toHaveBeenCalledWith('id-2');
+      expect(deleted).toHaveLength(1);
     });
 
     it('runs the orphaned-account clean up only when clean=true', async () => {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -20,7 +20,7 @@ import { FindOptionsRelations, ILike, IsNull, Not, Repository } from 'typeorm';
 import { AuthService } from '../auth/auth.service';
 import { basePartnerAccess, PartnerAccessService } from '../partner-access/partner-access.service';
 import { formatUserObject } from '../utils/serialize';
-import { generateRandomString } from '../utils/utils';
+import { generateRandomString, isProtectedReservedTestEmail } from '../utils/utils';
 import { AdminUpdateUserDto } from './dtos/admin-update-user.dto';
 import { CreateUserDto } from './dtos/create-user.dto';
 import { GetUserDto } from './dtos/get-user.dto';
@@ -349,7 +349,9 @@ export class UserService {
   // Count of test accounts a bulk delete would remove — lets superadmins preview
   // the impact before triggering the (irreversible) hard delete.
   public async countCypressTestUsers(): Promise<number> {
-    return this.userRepository.count({ where: CYPRESS_TEST_USER_EMAIL_FILTERS });
+    const users = await this.userRepository.find({ where: CYPRESS_TEST_USER_EMAIL_FILTERS });
+    // Exclude reserved accounts so the preview reflects what a delete would actually remove
+    return users.filter((user) => !isProtectedReservedTestEmail(user.email)).length;
   }
 
   public async deleteCypressTestUsers(clean = false): Promise<UserEntity[]> {
@@ -359,7 +361,10 @@ export class UserService {
         where: CYPRESS_TEST_USER_EMAIL_FILTERS,
       });
 
-      deletedUsers = await this.batchDeleteUsers(users);
+      // Skip reserved test accounts on non-production environments (see isProtectedReservedTestEmail)
+      const usersToDelete = users.filter((user) => !isProtectedReservedTestEmail(user.email));
+
+      deletedUsers = await this.batchDeleteUsers(usersToDelete);
     } catch (error) {
       // If this fails we don't want to break cypress tests but we want to be alerted
       this.logger.error(

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -264,3 +264,12 @@ export const mailchimpServerPrefix = getEnv(
 export const mailchimpWebhookSecret = process.env.MAILCHIMP_WEBHOOK_SECRET || '';
 
 export const frontSupportEmail = process.env.FRONT_SUPPORT_EMAIL || 'support@bloom.chayn.co';
+
+// Reserved Cypress test accounts that must survive the bulk test-user deletion on
+// non-production environments (they're needed for automated tests on staging). On
+// production they are not protected and can be deleted. Comma-separated and kept in
+// an env var so the specific addresses stay out of source control.
+export const cypressReservedTestEmails = (process.env.CYPRESS_RESERVED_TEST_EMAILS || '')
+  .split(',')
+  .map((email) => email.trim().toLowerCase())
+  .filter(Boolean);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,5 @@
 import { webcrypto } from 'crypto';
+import { cypressReservedTestEmails, isProduction } from './constants';
 const crypto = webcrypto as unknown as Crypto;
 
 export const generateRandomString = (length: number) => {
@@ -26,4 +27,12 @@ export const getAcronym = (text: string) => {
 
 export const isCypressTestEmail = (email: string): boolean => {
   return email.includes('cypresstestemail');
+};
+
+// Reserved Cypress test accounts are protected from the bulk test-user deletion on
+// non-production environments only. On production they are not protected, so a
+// superadmin cleanup there will still remove them.
+export const isProtectedReservedTestEmail = (email: string): boolean => {
+  if (isProduction || !email) return false;
+  return cypressReservedTestEmails.includes(email.trim().toLowerCase());
 };


### PR DESCRIPTION
Fixes messages received reporting metric to use `createdAt`

Also excludes reserved cypress test users from the deleteCypressUsers functionality