### PR TITLE
user_id + deleted_at on front + mailchimp

### DIFF
--- a/src/api/mailchimp/mailchimp-api.interfaces.ts
+++ b/src/api/mailchimp/mailchimp-api.interfaces.ts
@@ -19,8 +19,10 @@ export enum MAILCHIMP_CUSTOM_EVENTS {
 }
 
 export interface ListMemberCustomFields {
+  USERID?: string;
   NAME?: string;
   SIGNUPD?: string;
+  DELETED?: string;
   LACTIVED?: string;
   REMINDFREQ?: EMAIL_REMINDERS_FREQUENCY;
   PARTNERS?: string;

--- a/src/front-chat/front-chat.interface.ts
+++ b/src/front-chat/front-chat.interface.ts
@@ -28,8 +28,10 @@ export const FRONT_WEBHOOK_EVENT_TO_EVENT_NAME: Partial<Record<string, EVENT_NAM
 };
 
 export interface FrontChatContactCustomFields {
+  user_id?: string;
   signed_up_at?: string;
   last_active_at?: string;
+  deleted_at?: string;
   email_reminders_frequency?: EMAIL_REMINDERS_FREQUENCY;
   language?: string;
   // Coarse client context (no IP/GPS/raw User-Agent). browser_language is the browser's

--- a/src/service-user-profiles/service-user-profiles.service.spec.ts
+++ b/src/service-user-profiles/service-user-profiles.service.spec.ts
@@ -81,6 +81,7 @@ describe('Service user profiles', () => {
         name: mockUserEntity.name,
         userId: mockUserEntity.id,
         customFields: {
+          user_id: mockUserEntity.id,
           signed_up_at: createdAt,
           marketing_permission: mockUserEntity.contactPermission,
           service_emails_permission: mockUserEntity.serviceEmailsPermission,
@@ -109,6 +110,7 @@ describe('Service user profiles', () => {
           },
         ],
         merge_fields: {
+          USERID: mockUserEntity.id,
           SIGNUPD: createdAt,
           LACTIVED: lastActiveAt,
           NAME: mockUserEntity.name,
@@ -141,6 +143,7 @@ describe('Service user profiles', () => {
         name: mockUserEntity.name,
         userId: mockUserEntity.id,
         customFields: {
+          user_id: mockUserEntity.id,
           signed_up_at: createdAt,
           marketing_permission: mockUserEntity.contactPermission,
           service_emails_permission: mockUserEntity.serviceEmailsPermission,
@@ -170,6 +173,7 @@ describe('Service user profiles', () => {
           },
         ],
         merge_fields: {
+          USERID: mockUserEntity.id,
           SIGNUPD: mockUserEntity.createdAt.toISOString(),
           LACTIVED: lastActiveAt,
           NAME: mockUserEntity.name,
@@ -204,6 +208,7 @@ describe('Service user profiles', () => {
   describe('getOrCreateFrontContact', () => {
     // mockUserEntity has empty partnerAccess/courseUser, so therapy timestamps are omitted.
     const expectedCustomFields = {
+      user_id: mockUserEntity.id,
       signed_up_at: mockUserEntity.createdAt.toISOString(),
       marketing_permission: mockUserEntity.contactPermission,
       service_emails_permission: mockUserEntity.serviceEmailsPermission,
@@ -306,6 +311,7 @@ describe('Service user profiles', () => {
       expect(mockFrontChatService.updateContactCustomFields).toHaveBeenCalledTimes(1);
       expect(mockFrontChatService.updateContactCustomFields).toHaveBeenCalledWith(
         expect.objectContaining({
+          user_id: mockUserEntity.id,
           marketing_permission: mockUserEntity.contactPermission,
           service_emails_permission: mockUserEntity.serviceEmailsPermission,
           email_reminders_frequency: EMAIL_REMINDERS_FREQUENCY.TWO_MONTHS,
@@ -327,6 +333,7 @@ describe('Service user profiles', () => {
             },
           ],
           merge_fields: {
+            USERID: mockUserEntity.id,
             NAME: mockUserEntity.name,
             LACTIVED: lastActiveAt,
             REMINDFREQ: EMAIL_REMINDERS_FREQUENCY.TWO_MONTHS,
@@ -372,6 +379,7 @@ describe('Service user profiles', () => {
             },
           ],
           merge_fields: {
+            USERID: mockUser.id,
             NAME: mockUser.name,
             LACTIVED: lastActiveAt,
             REMINDFREQ: EMAIL_REMINDERS_FREQUENCY.TWO_MONTHS,
@@ -419,6 +427,31 @@ describe('Service user profiles', () => {
       expect(mockFrontChatService.updateContactCustomFields).toHaveBeenCalledTimes(1);
       expect(updateMailchimpProfile).toHaveBeenCalledWith(
         { ...serialisedMockUserData.mailchimpSchema, email_address: newEmail },
+        oldEmail,
+      );
+    });
+
+    it('should keep sending the same user id when the email changes', async () => {
+      const oldEmail = mockUserEntity.email;
+      const newEmail = 'newemail@test.com';
+
+      await service.updateServiceUserProfilesUser(
+        { ...mockUserEntity, email: newEmail },
+        true,
+        true,
+        false,
+        oldEmail,
+      );
+
+      expect(mockFrontChatService.updateContactCustomFields).toHaveBeenCalledWith(
+        expect.objectContaining({ user_id: mockUserEntity.id }),
+        newEmail,
+      );
+      expect(updateMailchimpProfile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email_address: newEmail,
+          merge_fields: expect.objectContaining({ USERID: mockUserEntity.id }),
+        }),
         oldEmail,
       );
     });
@@ -787,6 +820,93 @@ describe('Service user profiles', () => {
       await expect(
         service.updateServiceUserProfilesCourse(mockCourseUserEntity, mockUserEntity.email),
       ).resolves.not.toThrow();
+    });
+  });
+
+  describe('updateServiceUserProfilesUserDeleted', () => {
+    beforeEach(() => {
+      jest.spyOn(mockedUserRepository, 'findOne').mockResolvedValue({
+        ...mockUserEntity,
+        partnerAccess: [],
+        courseUser: [],
+      } as any);
+    });
+
+    it('should stamp the user id and deletion date on the Front Chat contact', async () => {
+      await service.updateServiceUserProfilesUserDeleted(mockUserEntity);
+
+      expect(mockFrontChatService.updateContactCustomFields).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_id: mockUserEntity.id,
+          deleted_at: expect.any(String),
+          // Front's PATCH replaces custom_fields wholesale, so the complete set is sent.
+          signed_up_at: mockUserEntity.createdAt.toISOString(),
+          language: mockUserEntity.signUpLanguage,
+        }),
+        mockUserEntity.email,
+      );
+
+      const [customFields] = jest.mocked(mockFrontChatService.updateContactCustomFields).mock
+        .calls[0];
+      expect(new Date(customFields.deleted_at as string).toString()).not.toBe('Invalid Date');
+    });
+
+    it('should stamp the user id and deletion date on the mailchimp profile and unsubscribe it', async () => {
+      await service.updateServiceUserProfilesUserDeleted(mockUserEntity);
+
+      // DELETED is a Mailchimp date merge field: MM/DD/YYYY, not an ISO datetime.
+      const [year, month, day] = new Date().toISOString().slice(0, 10).split('-');
+
+      expect(updateMailchimpProfile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'unsubscribed',
+          merge_fields: expect.objectContaining({
+            USERID: mockUserEntity.id,
+            DELETED: `${month}/${day}/${year}`,
+          }),
+        }),
+        mockUserEntity.email,
+      );
+    });
+
+    it('should stay unsubscribed when mailchimp recreates a missing member', async () => {
+      const mockedUpdate = jest.mocked(updateMailchimpProfile);
+      mockedUpdate.mockRejectedValueOnce(
+        Object.assign(new Error('Mailchimp error'), { status: 404 }),
+      );
+
+      await service.updateServiceUserProfilesUserDeleted(mockUserEntity);
+
+      expect(createMailchimpProfile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'unsubscribed',
+          merge_fields: expect.objectContaining({
+            USERID: mockUserEntity.id,
+            DELETED: expect.any(String),
+          }),
+        }),
+      );
+      mockedUpdate.mockReset();
+    });
+
+    it('should still update mailchimp when Front Chat fails', async () => {
+      jest
+        .mocked(mockFrontChatService.updateContactCustomFields)
+        .mockRejectedValue(new Error('Front Chat API call failed'));
+
+      await service.updateServiceUserProfilesUserDeleted(mockUserEntity);
+
+      expect(updateMailchimpProfile).toHaveBeenCalled();
+    });
+
+    it('skips for Cypress test emails', async () => {
+      await service.updateServiceUserProfilesUserDeleted({
+        ...mockUserEntity,
+        email: 'cypresstestemail+1@chayn.co',
+      } as any);
+
+      expect(mockFrontChatService.updateContactCustomFields).not.toHaveBeenCalled();
+      expect(updateMailchimpProfile).not.toHaveBeenCalled();
     });
   });
 

--- a/src/service-user-profiles/service-user-profiles.service.ts
+++ b/src/service-user-profiles/service-user-profiles.service.ts
@@ -256,6 +256,9 @@ export class ServiceUserProfilesService {
           ...profileData.merge_fields,
           ...(partialUpdate.merge_fields ?? {}),
         };
+        // The update's status wins over the one derived from the user record, so a deleted user
+        // isn't recreated as subscribed.
+        if (partialUpdate.status) profileData.status = partialUpdate.status;
         await createMailchimpProfile(profileData);
       } catch (recoverError) {
         const recoverStatus = (recoverError as { status?: number })?.status;
@@ -418,6 +421,42 @@ export class ServiceUserProfilesService {
     await this.syncFrontContactCustomFields(email);
 
     await this.syncMailchimpProfile(courseData.mailchimpSchema, email, 'course');
+  }
+
+  // Deleting an account anonymises the DB row (name and email are randomised) but keeps the id,
+  // so the id is all that still links the Front and Mailchimp contacts — which keep the original
+  // email — back to our records. Must run BEFORE the row is anonymised: both are keyed by email.
+  async updateServiceUserProfilesUserDeleted(user: UserEntity) {
+    const { email } = user;
+
+    if (isCypressTestEmail(email)) {
+      logger.log('Skipping service user profile deletion update for Cypress test email');
+      return;
+    }
+
+    const deletedAt = new Date().toISOString();
+    // Mailchimp date merge fields reject ISO datetimes. Sliced from the ISO string so the day is
+    // taken in UTC and can't shift under the server's timezone.
+    const [year, month, day] = deletedAt.slice(0, 10).split('-');
+    const deletedOn = `${month}/${day}/${year}`;
+
+    const userData = this.serializeUserData(user);
+
+    // Sync all custom fields to Front with the complete set (partial PATCH would wipe other fields).
+    await this.syncFrontContactCustomFields(email, { deleted_at: deletedAt });
+
+    // Unsubscribed so a deleted user stops receiving campaigns.
+    await this.syncMailchimpProfile(
+      {
+        ...userData.mailchimpSchema,
+        status: 'unsubscribed',
+        merge_fields: { ...userData.mailchimpSchema.merge_fields, DELETED: deletedOn },
+      },
+      email,
+      'user deleted',
+    );
+
+    logger.log('Updated service user profiles user deleted');
   }
 
   async updateServiceUserProfilesChatActivity(
@@ -583,6 +622,7 @@ export class ServiceUserProfilesService {
 
   serializeUserData(user: UserEntity) {
     const {
+      id,
       name,
       signUpLanguage,
       contactPermission,
@@ -593,6 +633,7 @@ export class ServiceUserProfilesService {
     const lastActiveAtString = lastActiveAt?.toISOString();
 
     const frontChatSchema: FrontChatContactCustomFields = {
+      user_id: id,
       marketing_permission: contactPermission,
       service_emails_permission: serviceEmailsPermission,
       email_reminders_frequency: emailRemindersFrequency,
@@ -613,6 +654,7 @@ export class ServiceUserProfilesService {
       ],
       language: signUpLanguage || LANGUAGE_DEFAULT,
       merge_fields: {
+        USERID: id,
         NAME: name,
         LACTIVED: lastActiveAtString,
         REMINDFREQ: emailRemindersFrequency,

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -71,6 +71,7 @@ jest.mock('src/api/mailchimp/mailchimp-api');
 
 describe('UserService', () => {
   let service: UserService;
+  let serviceUserProfilesService: ServiceUserProfilesService;
   let repo: Repository<UserEntity>;
   let mockAuthService: DeepMocked<AuthService>;
   let mockPartnerAccessService: DeepMocked<PartnerAccessService>;
@@ -129,6 +130,7 @@ describe('UserService', () => {
     }).compile();
 
     service = module.get<UserService>(UserService);
+    serviceUserProfilesService = module.get<ServiceUserProfilesService>(ServiceUserProfilesService);
     const logger = (service as any).logger as Logger;
     (logger as any).cls = mockClsService;
     repo = module.get<Repository<UserEntity>>(getRepositoryToken(UserEntity));
@@ -440,6 +442,48 @@ describe('UserService', () => {
       expect(mockTherapySessionServiceSpy).toHaveBeenCalled();
       expect(mockSubscriptionUserServiceSpy).toHaveBeenCalledWith(mockUserEntity.id);
       expect(mockAuthServiceSpy).toHaveBeenCalledWith(mockUserEntity.firebaseUid);
+    });
+
+    it('should mark the front and mailchimp profiles as deleted, keyed by the real email', async () => {
+      const repoSpySave = jest.spyOn(repo, 'save');
+
+      const user = await service.deleteUser(mockUserEntity);
+
+      // Sent with the pre-anonymisation email — the key both contacts are stored under.
+      expect(mockFrontChatService.updateContactCustomFields).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_id: mockUserEntity.id,
+          deleted_at: expect.any(String),
+        }),
+        mockUserEntity.email,
+      );
+      expect(updateMailchimpProfile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'unsubscribed',
+          merge_fields: expect.objectContaining({
+            USERID: mockUserEntity.id,
+            DELETED: expect.stringMatching(/^\d{2}\/\d{2}\/\d{4}$/),
+          }),
+        }),
+        mockUserEntity.email,
+      );
+
+      // The id survives anonymisation, so it remains the only link back to these profiles.
+      expect(user.id).toBe(mockUserEntity.id);
+      expect(user.email).not.toBe(mockUserEntity.email);
+      expect(repoSpySave).toHaveBeenCalled();
+    });
+
+    it('when updating service user profiles fails, it should still delete the user', async () => {
+      const repoSpySave = jest.spyOn(repo, 'save');
+      jest
+        .spyOn(serviceUserProfilesService, 'updateServiceUserProfilesUserDeleted')
+        .mockRejectedValueOnce(new Error('Front Chat API call failed'));
+
+      const user = await service.deleteUser(mockUserEntity);
+
+      expect(user.email).not.toBe(mockUserEntity.email);
+      expect(repoSpySave).toHaveBeenCalledTimes(1);
     });
 
     it('when user id supplied, but firebaseRequestFails, it should not throw', async () => {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -178,6 +178,16 @@ export class UserService {
       );
     }
 
+    // Must run before the row is anonymised below — the contacts are keyed by the real email.
+    // Deletion must not fail if this does.
+    try {
+      await this.serviceUserProfilesService.updateServiceUserProfilesUserDeleted(user);
+    } catch (err) {
+      this.logger.error(
+        `deleteUser - unable to update service user profiles for user ${user.id}: ${err?.message || 'unknown error'}`,
+      );
+    }
+
     try {
       // If they have subscriptions,redact the number
       await this.subscriptionUserService.softDeleteSubscriptionsForUser(user.id);


### PR DESCRIPTION
Adds `user_id` and `deleted_at` custom data fields to front and mailchimp. when a user deletes their account, these fields will be updated to ensure that the team can identify the user in these services after their data is anonymised